### PR TITLE
ObjC extension subproject

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,0 @@
-github "The-Wineskin-Project/ObjectiveC_Extension" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "WineskinCommunity/ObjectiveC_Extension" "9cda34929d17baf6c0a47a9a34e849fa09d255a7"

--- a/ObjectiveC_Extension/.gitignore
+++ b/ObjectiveC_Extension/.gitignore
@@ -1,0 +1,65 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+.DS_Store
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output
+
+# Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/

--- a/ObjectiveC_Extension/LICENSE
+++ b/ObjectiveC_Extension/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 vitor251093
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ObjectiveC_Extension/ObjectiveC_Extension.xcodeproj/project.pbxproj
+++ b/ObjectiveC_Extension/ObjectiveC_Extension.xcodeproj/project.pbxproj
@@ -1,0 +1,989 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4E0DE40E1FC703A2004AA363 /* NSTimer+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E0DE40C1FC703A2004AA363 /* NSTimer+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E0DE40F1FC703A2004AA363 /* NSTimer+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E0DE40D1FC703A2004AA363 /* NSTimer+Extension.m */; };
+		4E1181591FB200E800D8029F /* VMMView.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E1181571FB200E800D8029F /* VMMView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E11815A1FB200E800D8029F /* VMMView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E1181581FB200E800D8029F /* VMMView.m */; };
+		4E231F931F8191DD00148A30 /* VMMDeviceSimulator.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E231F911F8191DD00148A30 /* VMMDeviceSimulator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E231F941F8191DD00148A30 /* VMMDeviceSimulator.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E231F921F8191DD00148A30 /* VMMDeviceSimulator.m */; };
+		4E2462F32207793F00E5C02B /* VMMMenu.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E2462F12207793F00E5C02B /* VMMMenu.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E2462F42207793F00E5C02B /* VMMMenu.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E2462F22207793F00E5C02B /* VMMMenu.m */; };
+		4E34B2F41FD879DE001F0B4F /* VMMLocalizationUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E0DD3B81FD878F90033AA72 /* VMMLocalizationUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E37704B20517EB300AADB8A /* VMMPropertyList.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E37704920517EB300AADB8A /* VMMPropertyList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E37704C20517EB300AADB8A /* VMMPropertyList.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E37704A20517EB300AADB8A /* VMMPropertyList.m */; };
+		4E3771061FA7A57C00E2F511 /* VMMWebView.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E3771041FA7A57C00E2F511 /* VMMWebView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E3771071FA7A57C00E2F511 /* VMMWebView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E3771051FA7A57C00E2F511 /* VMMWebView.m */; };
+		4E3BD7031FAD2FCF00AF8418 /* VMMUUID.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E3BD7011FAD2FCF00AF8418 /* VMMUUID.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E3BD7041FAD2FCF00AF8418 /* VMMUUID.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E3BD7021FAD2FCF00AF8418 /* VMMUUID.m */; };
+		4E53A8A61F8587D90038BDFE /* NSScreen+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E53A8A41F8587D90038BDFE /* NSScreen+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E53A8A71F8587D90038BDFE /* NSScreen+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E53A8A51F8587D90038BDFE /* NSScreen+Extension.m */; };
+		4E5A45D91FC9FD7800FCEB42 /* VMMDockProgressIndicator.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E5A45D71FC9FD7800FCEB42 /* VMMDockProgressIndicator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E5A45DA1FC9FD7800FCEB42 /* VMMDockProgressIndicator.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E5A45D81FC9FD7800FCEB42 /* VMMDockProgressIndicator.m */; };
+		4E5A45DD1FCA103800FCEB42 /* NSBundle+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E5A45DB1FCA103800FCEB42 /* NSBundle+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E5A45DE1FCA103800FCEB42 /* NSBundle+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E5A45DC1FCA103800FCEB42 /* NSBundle+Extension.m */; };
+		4E66CA72214D54CF004293A5 /* ObjCExtensionConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 4EAA1FB9212D8A27006F1445 /* ObjCExtensionConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C51111F7E8EB700A187E9 /* ObjectiveC_Extension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E6C51071F7E8EB700A187E9 /* ObjectiveC_Extension.framework */; };
+		4E6C51161F7E8EB700A187E9 /* ObjectiveC_ExtensionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C51151F7E8EB700A187E9 /* ObjectiveC_ExtensionTests.m */; };
+		4E6C51181F7E8EB700A187E9 /* ObjectiveC_Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C510A1F7E8EB700A187E9 /* ObjectiveC_Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C51EA1F7E90A300A187E9 /* VMMVirtualKeycode.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C51E41F7E90A300A187E9 /* VMMVirtualKeycode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C51EB1F7E90A300A187E9 /* VMMVirtualKeycode.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C51E51F7E90A300A187E9 /* VMMVirtualKeycode.m */; };
+		4E6C51EC1F7E90A300A187E9 /* VMMDeviceObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C51E61F7E90A300A187E9 /* VMMDeviceObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C51ED1F7E90A300A187E9 /* VMMDeviceObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C51E71F7E90A300A187E9 /* VMMDeviceObserver.m */; };
+		4E6C51EE1F7E90A300A187E9 /* VMMUsageKeycode.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C51E81F7E90A300A187E9 /* VMMUsageKeycode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C51EF1F7E90A300A187E9 /* VMMUsageKeycode.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C51E91F7E90A300A187E9 /* VMMUsageKeycode.m */; };
+		4E6C521F1F7E911000A187E9 /* VMMAlert.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C51F11F7E911000A187E9 /* VMMAlert.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C52201F7E911000A187E9 /* VMMAlert.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C51F21F7E911000A187E9 /* VMMAlert.m */; };
+		4E6C52211F7E911000A187E9 /* NSArray+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C51F31F7E911000A187E9 /* NSArray+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C52221F7E911000A187E9 /* NSArray+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C51F41F7E911000A187E9 /* NSArray+Extension.m */; };
+		4E6C52231F7E911000A187E9 /* NSAttributedString+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C51F51F7E911000A187E9 /* NSAttributedString+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C52241F7E911000A187E9 /* NSAttributedString+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C51F61F7E911000A187E9 /* NSAttributedString+Extension.m */; };
+		4E6C52251F7E911000A187E9 /* NSColor+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C51F71F7E911000A187E9 /* NSColor+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C52261F7E911000A187E9 /* NSColor+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C51F81F7E911000A187E9 /* NSColor+Extension.m */; };
+		4E6C52271F7E911000A187E9 /* NSData+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C51F91F7E911000A187E9 /* NSData+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C52281F7E911000A187E9 /* NSData+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C51FA1F7E911000A187E9 /* NSData+Extension.m */; };
+		4E6C52291F7E911000A187E9 /* NSDateFormatter+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C51FB1F7E911000A187E9 /* NSDateFormatter+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C522A1F7E911000A187E9 /* NSDateFormatter+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C51FC1F7E911000A187E9 /* NSDateFormatter+Extension.m */; };
+		4E6C522B1F7E911000A187E9 /* NSFileManager+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C51FD1F7E911000A187E9 /* NSFileManager+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C522C1F7E911000A187E9 /* NSFileManager+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C51FE1F7E911000A187E9 /* NSFileManager+Extension.m */; };
+		4E6C522D1F7E911000A187E9 /* NSImage+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C51FF1F7E911000A187E9 /* NSImage+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C522E1F7E911000A187E9 /* NSImage+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C52001F7E911000A187E9 /* NSImage+Extension.m */; };
+		4E6C52311F7E911000A187E9 /* NSMenuItem+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C52031F7E911000A187E9 /* NSMenuItem+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C52321F7E911000A187E9 /* NSMenuItem+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C52041F7E911000A187E9 /* NSMenuItem+Extension.m */; };
+		4E6C52331F7E911000A187E9 /* NSMutableArray+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C52051F7E911000A187E9 /* NSMutableArray+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C52341F7E911000A187E9 /* NSMutableArray+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C52061F7E911000A187E9 /* NSMutableArray+Extension.m */; };
+		4E6C52351F7E911000A187E9 /* NSMutableAttributedString+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C52071F7E911000A187E9 /* NSMutableAttributedString+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C52361F7E911000A187E9 /* NSMutableAttributedString+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C52081F7E911000A187E9 /* NSMutableAttributedString+Extension.m */; };
+		4E6C52371F7E911000A187E9 /* NSMutableDictionary+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C52091F7E911000A187E9 /* NSMutableDictionary+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C52381F7E911000A187E9 /* NSMutableDictionary+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C520A1F7E911000A187E9 /* NSMutableDictionary+Extension.m */; };
+		4E6C52391F7E911000A187E9 /* NSMutableURLRequest+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C520B1F7E911000A187E9 /* NSMutableURLRequest+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C523A1F7E911000A187E9 /* NSMutableURLRequest+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C520C1F7E911000A187E9 /* NSMutableURLRequest+Extension.m */; };
+		4E6C523B1F7E911000A187E9 /* NSRunningApplication+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C520D1F7E911000A187E9 /* NSRunningApplication+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C523C1F7E911000A187E9 /* NSRunningApplication+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C520E1F7E911000A187E9 /* NSRunningApplication+Extension.m */; };
+		4E6C523D1F7E911000A187E9 /* NSSavePanel+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C520F1F7E911000A187E9 /* NSSavePanel+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C523E1F7E911000A187E9 /* NSSavePanel+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C52101F7E911000A187E9 /* NSSavePanel+Extension.m */; };
+		4E6C523F1F7E911000A187E9 /* NSString+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C52111F7E911000A187E9 /* NSString+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C52401F7E911000A187E9 /* NSString+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C52121F7E911000A187E9 /* NSString+Extension.m */; };
+		4E6C52411F7E911000A187E9 /* NSTask+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C52131F7E911000A187E9 /* NSTask+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C52421F7E911000A187E9 /* NSTask+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C52141F7E911000A187E9 /* NSTask+Extension.m */; };
+		4E6C52431F7E911000A187E9 /* NSText+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C52151F7E911000A187E9 /* NSText+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C52441F7E911000A187E9 /* NSText+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C52161F7E911000A187E9 /* NSText+Extension.m */; };
+		4E6C52451F7E911000A187E9 /* NSThread+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C52171F7E911000A187E9 /* NSThread+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C52461F7E911000A187E9 /* NSThread+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C52181F7E911000A187E9 /* NSThread+Extension.m */; };
+		4E6C52471F7E911000A187E9 /* NSUnarchiver+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C52191F7E911000A187E9 /* NSUnarchiver+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C52481F7E911000A187E9 /* NSUnarchiver+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C521A1F7E911000A187E9 /* NSUnarchiver+Extension.m */; };
+		4E6C52491F7E911000A187E9 /* NSUserDefaults+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C521B1F7E911000A187E9 /* NSUserDefaults+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C524A1F7E911000A187E9 /* NSUserDefaults+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C521C1F7E911000A187E9 /* NSUserDefaults+Extension.m */; };
+		4E6C524B1F7E911000A187E9 /* NSView+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C521D1F7E911000A187E9 /* NSView+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C524C1F7E911000A187E9 /* NSView+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C521E1F7E911000A187E9 /* NSView+Extension.m */; };
+		4E6C525D1F7E944F00A187E9 /* SZJsonParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C525B1F7E944F00A187E9 /* SZJsonParser.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4E6C525E1F7E944F00A187E9 /* SZJsonParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C525C1F7E944F00A187E9 /* SZJsonParser.m */; };
+		4E6C52681F7E953A00A187E9 /* NKFTPManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C52611F7E953A00A187E9 /* NKFTPManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C52691F7E953A00A187E9 /* NKFTPManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C52621F7E953A00A187E9 /* NKFTPManager.m */; };
+		4E6C526A1F7E953A00A187E9 /* VMMLogUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C52631F7E953A00A187E9 /* VMMLogUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C526B1F7E953A00A187E9 /* VMMUserNotificationCenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C52641F7E953A00A187E9 /* VMMUserNotificationCenter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C526C1F7E953A00A187E9 /* VMMUserNotificationCenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C52651F7E953A00A187E9 /* VMMUserNotificationCenter.m */; };
+		4E6C526D1F7E953A00A187E9 /* VMMVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C52661F7E953A00A187E9 /* VMMVersion.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C526E1F7E953A00A187E9 /* VMMVersion.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C52671F7E953A00A187E9 /* VMMVersion.m */; };
+		4E6C52711F7E954D00A187E9 /* VMMComputerInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E6C526F1F7E954D00A187E9 /* VMMComputerInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E6C52721F7E954D00A187E9 /* VMMComputerInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C52701F7E954D00A187E9 /* VMMComputerInformation.m */; };
+		4E6C52751F7E9D6400A187E9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E6C52741F7E9D6400A187E9 /* Cocoa.framework */; };
+		4E6C52771F7E9D6D00A187E9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E6C52761F7E9D6D00A187E9 /* Foundation.framework */; };
+		4E6C52791F7E9E1400A187E9 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E6C52781F7E9E1400A187E9 /* IOKit.framework */; };
+		4E6C527B1F7E9E4000A187E9 /* CoreImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E6C527A1F7E9E4000A187E9 /* CoreImage.framework */; };
+		4E6C527D1F7E9E4C00A187E9 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E6C527C1F7E9E4C00A187E9 /* Carbon.framework */; };
+		4E6C52881F7EA42700A187E9 /* NSArrayTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C52851F7EA42700A187E9 /* NSArrayTests.m */; };
+		4E6C52891F7EA42700A187E9 /* NSStringTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C52861F7EA42700A187E9 /* NSStringTests.m */; };
+		4E6C52941F7EB50300A187E9 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4E6C52961F7EB50300A187E9 /* Localizable.strings */; };
+		4E7D41B921665F2C001BEADB /* VMMVideoCardManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E7D41B721665F2C001BEADB /* VMMVideoCardManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E7D41BA21665F2C001BEADB /* VMMVideoCardManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E7D41B821665F2C001BEADB /* VMMVideoCardManager.m */; };
+		4E9986701FEEC85600E434E4 /* NSApplication+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E99866E1FEEC85600E434E4 /* NSApplication+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E9986711FEEC85600E434E4 /* NSApplication+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E99866F1FEEC85600E434E4 /* NSApplication+Extension.m */; };
+		4EA035A81F9532E10059C2C5 /* VMMKeyCaptureField.h in Headers */ = {isa = PBXBuildFile; fileRef = 4EA035A61F9532E10059C2C5 /* VMMKeyCaptureField.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4EA035A91F9532E10059C2C5 /* VMMKeyCaptureField.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EA035A71F9532E10059C2C5 /* VMMKeyCaptureField.m */; };
+		4EA69BD41FC8DDEA00C70100 /* NSWorkspace+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4EA69BD21FC8DDEA00C70100 /* NSWorkspace+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4EA69BD51FC8DDEA00C70100 /* NSWorkspace+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EA69BD31FC8DDEA00C70100 /* NSWorkspace+Extension.m */; };
+		4EAD49251FBBB5AE008B562F /* NSColorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EAD49241FBBB5AE008B562F /* NSColorTests.m */; };
+		4EB392E11FC479060098F987 /* VMMTextFileView.h in Headers */ = {isa = PBXBuildFile; fileRef = 4EB392DF1FC479060098F987 /* VMMTextFileView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4EB392E21FC479060098F987 /* VMMTextFileView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EB392E01FC479060098F987 /* VMMTextFileView.m */; };
+		4ECB93A620289E4B00F0A369 /* VMMParentalControls.h in Headers */ = {isa = PBXBuildFile; fileRef = 4ECB93A420289E4B00F0A369 /* VMMParentalControls.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4ECB93A720289E4B00F0A369 /* VMMParentalControls.m in Sources */ = {isa = PBXBuildFile; fileRef = 4ECB93A520289E4B00F0A369 /* VMMParentalControls.m */; };
+		4EE52847205EC3560005F335 /* VMMVideoCard.h in Headers */ = {isa = PBXBuildFile; fileRef = 4EE52845205EC3560005F335 /* VMMVideoCard.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4EE52848205EC3560005F335 /* VMMVideoCard.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EE52846205EC3560005F335 /* VMMVideoCard.m */; };
+		4EEBF4701FAE238F00CE31A0 /* NSMutableString+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4EEBF46E1FAE238F00CE31A0 /* NSMutableString+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4EEBF4711FAE238F00CE31A0 /* NSMutableString+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EEBF46F1FAE238F00CE31A0 /* NSMutableString+Extension.m */; };
+		4EF16B1F1F8E36A600A78DC0 /* VMMModals.h in Headers */ = {isa = PBXBuildFile; fileRef = 4EF16B1D1F8E36A600A78DC0 /* VMMModals.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4EF16B201F8E36A600A78DC0 /* VMMModals.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EF16B1E1F8E36A600A78DC0 /* VMMModals.m */; };
+		4EFA51931FE96C8C002D68FC /* NSException+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4EFA51911FE96C8C002D68FC /* NSException+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4EFA51941FE96C8C002D68FC /* NSException+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EFA51921FE96C8C002D68FC /* NSException+Extension.m */; };
+		4EFA51961FE9710B002D68FC /* VMMLogUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EFA51951FE9710B002D68FC /* VMMLogUtility.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		4E6C51121F7E8EB700A187E9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4E6C50FE1F7E8EB700A187E9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4E6C51061F7E8EB700A187E9;
+			remoteInfo = ObjectiveC_Extension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		4E0DD3B81FD878F90033AA72 /* VMMLocalizationUtility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMMLocalizationUtility.h; sourceTree = "<group>"; };
+		4E0DE40C1FC703A2004AA363 /* NSTimer+Extension.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSTimer+Extension.h"; sourceTree = "<group>"; };
+		4E0DE40D1FC703A2004AA363 /* NSTimer+Extension.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSTimer+Extension.m"; sourceTree = "<group>"; };
+		4E1181571FB200E800D8029F /* VMMView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMMView.h; sourceTree = "<group>"; };
+		4E1181581FB200E800D8029F /* VMMView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VMMView.m; sourceTree = "<group>"; };
+		4E231F911F8191DD00148A30 /* VMMDeviceSimulator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMMDeviceSimulator.h; sourceTree = "<group>"; };
+		4E231F921F8191DD00148A30 /* VMMDeviceSimulator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VMMDeviceSimulator.m; sourceTree = "<group>"; };
+		4E2462F12207793F00E5C02B /* VMMMenu.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMMMenu.h; sourceTree = "<group>"; };
+		4E2462F22207793F00E5C02B /* VMMMenu.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VMMMenu.m; sourceTree = "<group>"; };
+		4E37704920517EB300AADB8A /* VMMPropertyList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMMPropertyList.h; sourceTree = "<group>"; };
+		4E37704A20517EB300AADB8A /* VMMPropertyList.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VMMPropertyList.m; sourceTree = "<group>"; };
+		4E3771041FA7A57C00E2F511 /* VMMWebView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMMWebView.h; sourceTree = "<group>"; };
+		4E3771051FA7A57C00E2F511 /* VMMWebView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VMMWebView.m; sourceTree = "<group>"; };
+		4E3BD7011FAD2FCF00AF8418 /* VMMUUID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMMUUID.h; sourceTree = "<group>"; };
+		4E3BD7021FAD2FCF00AF8418 /* VMMUUID.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VMMUUID.m; sourceTree = "<group>"; };
+		4E3EE4641F82BF42008A5CC3 /* CREDITS */ = {isa = PBXFileReference; lastKnownFileType = text; path = CREDITS; sourceTree = "<group>"; };
+		4E4CD93720897CF5008CF4F7 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
+		4E53A8A41F8587D90038BDFE /* NSScreen+Extension.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSScreen+Extension.h"; sourceTree = "<group>"; };
+		4E53A8A51F8587D90038BDFE /* NSScreen+Extension.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSScreen+Extension.m"; sourceTree = "<group>"; };
+		4E5A45D71FC9FD7800FCEB42 /* VMMDockProgressIndicator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMMDockProgressIndicator.h; sourceTree = "<group>"; };
+		4E5A45D81FC9FD7800FCEB42 /* VMMDockProgressIndicator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VMMDockProgressIndicator.m; sourceTree = "<group>"; };
+		4E5A45DB1FCA103800FCEB42 /* NSBundle+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSBundle+Extension.h"; sourceTree = "<group>"; };
+		4E5A45DC1FCA103800FCEB42 /* NSBundle+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSBundle+Extension.m"; sourceTree = "<group>"; };
+		4E6C51071F7E8EB700A187E9 /* ObjectiveC_Extension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ObjectiveC_Extension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4E6C510A1F7E8EB700A187E9 /* ObjectiveC_Extension.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjectiveC_Extension.h; sourceTree = "<group>"; };
+		4E6C510B1F7E8EB700A187E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4E6C51101F7E8EB700A187E9 /* ObjectiveC_ExtensionTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ObjectiveC_ExtensionTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4E6C51151F7E8EB700A187E9 /* ObjectiveC_ExtensionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjectiveC_ExtensionTests.m; sourceTree = "<group>"; };
+		4E6C51171F7E8EB700A187E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4E6C51E41F7E90A300A187E9 /* VMMVirtualKeycode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMMVirtualKeycode.h; sourceTree = "<group>"; };
+		4E6C51E51F7E90A300A187E9 /* VMMVirtualKeycode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VMMVirtualKeycode.m; sourceTree = "<group>"; };
+		4E6C51E61F7E90A300A187E9 /* VMMDeviceObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMMDeviceObserver.h; sourceTree = "<group>"; };
+		4E6C51E71F7E90A300A187E9 /* VMMDeviceObserver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VMMDeviceObserver.m; sourceTree = "<group>"; };
+		4E6C51E81F7E90A300A187E9 /* VMMUsageKeycode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMMUsageKeycode.h; sourceTree = "<group>"; };
+		4E6C51E91F7E90A300A187E9 /* VMMUsageKeycode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VMMUsageKeycode.m; sourceTree = "<group>"; };
+		4E6C51F11F7E911000A187E9 /* VMMAlert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMMAlert.h; sourceTree = "<group>"; };
+		4E6C51F21F7E911000A187E9 /* VMMAlert.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VMMAlert.m; sourceTree = "<group>"; };
+		4E6C51F31F7E911000A187E9 /* NSArray+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+Extension.h"; sourceTree = "<group>"; };
+		4E6C51F41F7E911000A187E9 /* NSArray+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+Extension.m"; sourceTree = "<group>"; };
+		4E6C51F51F7E911000A187E9 /* NSAttributedString+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSAttributedString+Extension.h"; sourceTree = "<group>"; };
+		4E6C51F61F7E911000A187E9 /* NSAttributedString+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSAttributedString+Extension.m"; sourceTree = "<group>"; };
+		4E6C51F71F7E911000A187E9 /* NSColor+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSColor+Extension.h"; sourceTree = "<group>"; };
+		4E6C51F81F7E911000A187E9 /* NSColor+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSColor+Extension.m"; sourceTree = "<group>"; };
+		4E6C51F91F7E911000A187E9 /* NSData+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+Extension.h"; sourceTree = "<group>"; };
+		4E6C51FA1F7E911000A187E9 /* NSData+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+Extension.m"; sourceTree = "<group>"; };
+		4E6C51FB1F7E911000A187E9 /* NSDateFormatter+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDateFormatter+Extension.h"; sourceTree = "<group>"; };
+		4E6C51FC1F7E911000A187E9 /* NSDateFormatter+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDateFormatter+Extension.m"; sourceTree = "<group>"; };
+		4E6C51FD1F7E911000A187E9 /* NSFileManager+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSFileManager+Extension.h"; sourceTree = "<group>"; };
+		4E6C51FE1F7E911000A187E9 /* NSFileManager+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSFileManager+Extension.m"; sourceTree = "<group>"; };
+		4E6C51FF1F7E911000A187E9 /* NSImage+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSImage+Extension.h"; sourceTree = "<group>"; };
+		4E6C52001F7E911000A187E9 /* NSImage+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSImage+Extension.m"; sourceTree = "<group>"; };
+		4E6C52031F7E911000A187E9 /* NSMenuItem+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMenuItem+Extension.h"; sourceTree = "<group>"; };
+		4E6C52041F7E911000A187E9 /* NSMenuItem+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMenuItem+Extension.m"; sourceTree = "<group>"; };
+		4E6C52051F7E911000A187E9 /* NSMutableArray+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableArray+Extension.h"; sourceTree = "<group>"; };
+		4E6C52061F7E911000A187E9 /* NSMutableArray+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableArray+Extension.m"; sourceTree = "<group>"; };
+		4E6C52071F7E911000A187E9 /* NSMutableAttributedString+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableAttributedString+Extension.h"; sourceTree = "<group>"; };
+		4E6C52081F7E911000A187E9 /* NSMutableAttributedString+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableAttributedString+Extension.m"; sourceTree = "<group>"; };
+		4E6C52091F7E911000A187E9 /* NSMutableDictionary+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableDictionary+Extension.h"; sourceTree = "<group>"; };
+		4E6C520A1F7E911000A187E9 /* NSMutableDictionary+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableDictionary+Extension.m"; sourceTree = "<group>"; };
+		4E6C520B1F7E911000A187E9 /* NSMutableURLRequest+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableURLRequest+Extension.h"; sourceTree = "<group>"; };
+		4E6C520C1F7E911000A187E9 /* NSMutableURLRequest+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableURLRequest+Extension.m"; sourceTree = "<group>"; };
+		4E6C520D1F7E911000A187E9 /* NSRunningApplication+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSRunningApplication+Extension.h"; sourceTree = "<group>"; };
+		4E6C520E1F7E911000A187E9 /* NSRunningApplication+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSRunningApplication+Extension.m"; sourceTree = "<group>"; };
+		4E6C520F1F7E911000A187E9 /* NSSavePanel+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSSavePanel+Extension.h"; sourceTree = "<group>"; };
+		4E6C52101F7E911000A187E9 /* NSSavePanel+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSSavePanel+Extension.m"; sourceTree = "<group>"; };
+		4E6C52111F7E911000A187E9 /* NSString+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+Extension.h"; sourceTree = "<group>"; };
+		4E6C52121F7E911000A187E9 /* NSString+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+Extension.m"; sourceTree = "<group>"; };
+		4E6C52131F7E911000A187E9 /* NSTask+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSTask+Extension.h"; sourceTree = "<group>"; };
+		4E6C52141F7E911000A187E9 /* NSTask+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSTask+Extension.m"; sourceTree = "<group>"; };
+		4E6C52151F7E911000A187E9 /* NSText+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSText+Extension.h"; sourceTree = "<group>"; };
+		4E6C52161F7E911000A187E9 /* NSText+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSText+Extension.m"; sourceTree = "<group>"; };
+		4E6C52171F7E911000A187E9 /* NSThread+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSThread+Extension.h"; sourceTree = "<group>"; };
+		4E6C52181F7E911000A187E9 /* NSThread+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSThread+Extension.m"; sourceTree = "<group>"; };
+		4E6C52191F7E911000A187E9 /* NSUnarchiver+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSUnarchiver+Extension.h"; sourceTree = "<group>"; };
+		4E6C521A1F7E911000A187E9 /* NSUnarchiver+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSUnarchiver+Extension.m"; sourceTree = "<group>"; };
+		4E6C521B1F7E911000A187E9 /* NSUserDefaults+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSUserDefaults+Extension.h"; sourceTree = "<group>"; };
+		4E6C521C1F7E911000A187E9 /* NSUserDefaults+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSUserDefaults+Extension.m"; sourceTree = "<group>"; };
+		4E6C521D1F7E911000A187E9 /* NSView+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSView+Extension.h"; sourceTree = "<group>"; };
+		4E6C521E1F7E911000A187E9 /* NSView+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSView+Extension.m"; sourceTree = "<group>"; };
+		4E6C525B1F7E944F00A187E9 /* SZJsonParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SZJsonParser.h; sourceTree = "<group>"; };
+		4E6C525C1F7E944F00A187E9 /* SZJsonParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SZJsonParser.m; sourceTree = "<group>"; };
+		4E6C52611F7E953A00A187E9 /* NKFTPManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NKFTPManager.h; sourceTree = "<group>"; };
+		4E6C52621F7E953A00A187E9 /* NKFTPManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NKFTPManager.m; sourceTree = "<group>"; };
+		4E6C52631F7E953A00A187E9 /* VMMLogUtility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMMLogUtility.h; sourceTree = "<group>"; };
+		4E6C52641F7E953A00A187E9 /* VMMUserNotificationCenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMMUserNotificationCenter.h; sourceTree = "<group>"; };
+		4E6C52651F7E953A00A187E9 /* VMMUserNotificationCenter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VMMUserNotificationCenter.m; sourceTree = "<group>"; };
+		4E6C52661F7E953A00A187E9 /* VMMVersion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMMVersion.h; sourceTree = "<group>"; };
+		4E6C52671F7E953A00A187E9 /* VMMVersion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VMMVersion.m; sourceTree = "<group>"; };
+		4E6C526F1F7E954D00A187E9 /* VMMComputerInformation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMMComputerInformation.h; sourceTree = "<group>"; };
+		4E6C52701F7E954D00A187E9 /* VMMComputerInformation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VMMComputerInformation.m; sourceTree = "<group>"; };
+		4E6C52741F7E9D6400A187E9 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		4E6C52761F7E9D6D00A187E9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		4E6C52781F7E9E1400A187E9 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		4E6C527A1F7E9E4000A187E9 /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = System/Library/Frameworks/CoreImage.framework; sourceTree = SDKROOT; };
+		4E6C527C1F7E9E4C00A187E9 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
+		4E6C52851F7EA42700A187E9 /* NSArrayTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSArrayTests.m; sourceTree = "<group>"; };
+		4E6C52861F7EA42700A187E9 /* NSStringTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSStringTests.m; sourceTree = "<group>"; };
+		4E6C52951F7EB50300A187E9 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4E6C52971F7EB51D00A187E9 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4E6C52981F7EB52100A187E9 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4E6C52991F7EB52500A187E9 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		4E6C529A1F7EB52A00A187E9 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4E7D41B721665F2C001BEADB /* VMMVideoCardManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMMVideoCardManager.h; sourceTree = "<group>"; };
+		4E7D41B821665F2C001BEADB /* VMMVideoCardManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VMMVideoCardManager.m; sourceTree = "<group>"; };
+		4E99866E1FEEC85600E434E4 /* NSApplication+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSApplication+Extension.h"; sourceTree = "<group>"; };
+		4E99866F1FEEC85600E434E4 /* NSApplication+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSApplication+Extension.m"; sourceTree = "<group>"; };
+		4E9C67642180C43800F6C17E /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
+		4EA035A61F9532E10059C2C5 /* VMMKeyCaptureField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMMKeyCaptureField.h; sourceTree = "<group>"; };
+		4EA035A71F9532E10059C2C5 /* VMMKeyCaptureField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VMMKeyCaptureField.m; sourceTree = "<group>"; };
+		4EA69BD21FC8DDEA00C70100 /* NSWorkspace+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSWorkspace+Extension.h"; sourceTree = "<group>"; };
+		4EA69BD31FC8DDEA00C70100 /* NSWorkspace+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSWorkspace+Extension.m"; sourceTree = "<group>"; };
+		4EAA1FB9212D8A27006F1445 /* ObjCExtensionConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCExtensionConfig.h; sourceTree = "<group>"; };
+		4EAD49241FBBB5AE008B562F /* NSColorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSColorTests.m; sourceTree = "<group>"; };
+		4EB392DF1FC479060098F987 /* VMMTextFileView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMMTextFileView.h; sourceTree = "<group>"; };
+		4EB392E01FC479060098F987 /* VMMTextFileView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VMMTextFileView.m; sourceTree = "<group>"; };
+		4ECB93A420289E4B00F0A369 /* VMMParentalControls.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMMParentalControls.h; sourceTree = "<group>"; };
+		4ECB93A520289E4B00F0A369 /* VMMParentalControls.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VMMParentalControls.m; sourceTree = "<group>"; };
+		4ED18760206BF11F002BF81C /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		4EE52845205EC3560005F335 /* VMMVideoCard.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMMVideoCard.h; sourceTree = "<group>"; };
+		4EE52846205EC3560005F335 /* VMMVideoCard.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VMMVideoCard.m; sourceTree = "<group>"; };
+		4EEBF46E1FAE238F00CE31A0 /* NSMutableString+Extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableString+Extension.h"; sourceTree = "<group>"; };
+		4EEBF46F1FAE238F00CE31A0 /* NSMutableString+Extension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableString+Extension.m"; sourceTree = "<group>"; };
+		4EF16B1D1F8E36A600A78DC0 /* VMMModals.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMMModals.h; sourceTree = "<group>"; };
+		4EF16B1E1F8E36A600A78DC0 /* VMMModals.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VMMModals.m; sourceTree = "<group>"; };
+		4EFA51911FE96C8C002D68FC /* NSException+Extension.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSException+Extension.h"; sourceTree = "<group>"; };
+		4EFA51921FE96C8C002D68FC /* NSException+Extension.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSException+Extension.m"; sourceTree = "<group>"; };
+		4EFA51951FE9710B002D68FC /* VMMLogUtility.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VMMLogUtility.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		4E6C51031F7E8EB700A187E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4E6C527D1F7E9E4C00A187E9 /* Carbon.framework in Frameworks */,
+				4E6C527B1F7E9E4000A187E9 /* CoreImage.framework in Frameworks */,
+				4E6C52791F7E9E1400A187E9 /* IOKit.framework in Frameworks */,
+				4E6C52771F7E9D6D00A187E9 /* Foundation.framework in Frameworks */,
+				4E6C52751F7E9D6400A187E9 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4E6C510D1F7E8EB700A187E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4E6C51111F7E8EB700A187E9 /* ObjectiveC_Extension.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		4E6C50FD1F7E8EB700A187E9 = {
+			isa = PBXGroup;
+			children = (
+				4ED18760206BF11F002BF81C /* README.md */,
+				4E6C51091F7E8EB700A187E9 /* ObjectiveC_Extension */,
+				4E6C51141F7E8EB700A187E9 /* ObjectiveC_ExtensionTests */,
+				4E6C51081F7E8EB700A187E9 /* Products */,
+				4E6C52731F7E9D6400A187E9 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		4E6C51081F7E8EB700A187E9 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				4E6C51071F7E8EB700A187E9 /* ObjectiveC_Extension.framework */,
+				4E6C51101F7E8EB700A187E9 /* ObjectiveC_ExtensionTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		4E6C51091F7E8EB700A187E9 /* ObjectiveC_Extension */ = {
+			isa = PBXGroup;
+			children = (
+				4E6C51E31F7E908800A187E9 /* Devices */,
+				4E6C51F01F7E90B800A187E9 /* Extensions */,
+				4E6C525A1F7E943900A187E9 /* Legacy */,
+				4E6C52601F7E950900A187E9 /* Utilities */,
+				4EA035A51F9532C80059C2C5 /* Views */,
+				4E6C52961F7EB50300A187E9 /* Localizable.strings */,
+				4EAA1FB9212D8A27006F1445 /* ObjCExtensionConfig.h */,
+				4E6C510A1F7E8EB700A187E9 /* ObjectiveC_Extension.h */,
+				4E6C510B1F7E8EB700A187E9 /* Info.plist */,
+				4E3EE4641F82BF42008A5CC3 /* CREDITS */,
+			);
+			path = ObjectiveC_Extension;
+			sourceTree = "<group>";
+		};
+		4E6C51141F7E8EB700A187E9 /* ObjectiveC_ExtensionTests */ = {
+			isa = PBXGroup;
+			children = (
+				4E6C527E1F7EA3E500A187E9 /* Functions */,
+				4E6C51151F7E8EB700A187E9 /* ObjectiveC_ExtensionTests.m */,
+				4E6C51171F7E8EB700A187E9 /* Info.plist */,
+			);
+			path = ObjectiveC_ExtensionTests;
+			sourceTree = "<group>";
+		};
+		4E6C51E31F7E908800A187E9 /* Devices */ = {
+			isa = PBXGroup;
+			children = (
+				4E6C51E61F7E90A300A187E9 /* VMMDeviceObserver.h */,
+				4E6C51E71F7E90A300A187E9 /* VMMDeviceObserver.m */,
+				4E231F911F8191DD00148A30 /* VMMDeviceSimulator.h */,
+				4E231F921F8191DD00148A30 /* VMMDeviceSimulator.m */,
+				4E6C51E81F7E90A300A187E9 /* VMMUsageKeycode.h */,
+				4E6C51E91F7E90A300A187E9 /* VMMUsageKeycode.m */,
+				4E6C51E41F7E90A300A187E9 /* VMMVirtualKeycode.h */,
+				4E6C51E51F7E90A300A187E9 /* VMMVirtualKeycode.m */,
+			);
+			name = Devices;
+			sourceTree = "<group>";
+		};
+		4E6C51F01F7E90B800A187E9 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				4E99866E1FEEC85600E434E4 /* NSApplication+Extension.h */,
+				4E99866F1FEEC85600E434E4 /* NSApplication+Extension.m */,
+				4E6C51F31F7E911000A187E9 /* NSArray+Extension.h */,
+				4E6C51F41F7E911000A187E9 /* NSArray+Extension.m */,
+				4E6C51F51F7E911000A187E9 /* NSAttributedString+Extension.h */,
+				4E6C51F61F7E911000A187E9 /* NSAttributedString+Extension.m */,
+				4E5A45DB1FCA103800FCEB42 /* NSBundle+Extension.h */,
+				4E5A45DC1FCA103800FCEB42 /* NSBundle+Extension.m */,
+				4E6C51F71F7E911000A187E9 /* NSColor+Extension.h */,
+				4E6C51F81F7E911000A187E9 /* NSColor+Extension.m */,
+				4E6C51F91F7E911000A187E9 /* NSData+Extension.h */,
+				4E6C51FA1F7E911000A187E9 /* NSData+Extension.m */,
+				4E6C51FB1F7E911000A187E9 /* NSDateFormatter+Extension.h */,
+				4E6C51FC1F7E911000A187E9 /* NSDateFormatter+Extension.m */,
+				4EFA51911FE96C8C002D68FC /* NSException+Extension.h */,
+				4EFA51921FE96C8C002D68FC /* NSException+Extension.m */,
+				4E6C51FD1F7E911000A187E9 /* NSFileManager+Extension.h */,
+				4E6C51FE1F7E911000A187E9 /* NSFileManager+Extension.m */,
+				4E6C51FF1F7E911000A187E9 /* NSImage+Extension.h */,
+				4E6C52001F7E911000A187E9 /* NSImage+Extension.m */,
+				4E6C52031F7E911000A187E9 /* NSMenuItem+Extension.h */,
+				4E6C52041F7E911000A187E9 /* NSMenuItem+Extension.m */,
+				4E6C52051F7E911000A187E9 /* NSMutableArray+Extension.h */,
+				4E6C52061F7E911000A187E9 /* NSMutableArray+Extension.m */,
+				4E6C52071F7E911000A187E9 /* NSMutableAttributedString+Extension.h */,
+				4E6C52081F7E911000A187E9 /* NSMutableAttributedString+Extension.m */,
+				4E6C52091F7E911000A187E9 /* NSMutableDictionary+Extension.h */,
+				4E6C520A1F7E911000A187E9 /* NSMutableDictionary+Extension.m */,
+				4EEBF46E1FAE238F00CE31A0 /* NSMutableString+Extension.h */,
+				4EEBF46F1FAE238F00CE31A0 /* NSMutableString+Extension.m */,
+				4E6C520B1F7E911000A187E9 /* NSMutableURLRequest+Extension.h */,
+				4E6C520C1F7E911000A187E9 /* NSMutableURLRequest+Extension.m */,
+				4E6C520D1F7E911000A187E9 /* NSRunningApplication+Extension.h */,
+				4E6C520E1F7E911000A187E9 /* NSRunningApplication+Extension.m */,
+				4E6C520F1F7E911000A187E9 /* NSSavePanel+Extension.h */,
+				4E6C52101F7E911000A187E9 /* NSSavePanel+Extension.m */,
+				4E53A8A41F8587D90038BDFE /* NSScreen+Extension.h */,
+				4E53A8A51F8587D90038BDFE /* NSScreen+Extension.m */,
+				4E6C52111F7E911000A187E9 /* NSString+Extension.h */,
+				4E6C52121F7E911000A187E9 /* NSString+Extension.m */,
+				4E6C52131F7E911000A187E9 /* NSTask+Extension.h */,
+				4E6C52141F7E911000A187E9 /* NSTask+Extension.m */,
+				4E6C52151F7E911000A187E9 /* NSText+Extension.h */,
+				4E6C52161F7E911000A187E9 /* NSText+Extension.m */,
+				4E6C52171F7E911000A187E9 /* NSThread+Extension.h */,
+				4E6C52181F7E911000A187E9 /* NSThread+Extension.m */,
+				4E0DE40C1FC703A2004AA363 /* NSTimer+Extension.h */,
+				4E0DE40D1FC703A2004AA363 /* NSTimer+Extension.m */,
+				4E6C52191F7E911000A187E9 /* NSUnarchiver+Extension.h */,
+				4E6C521A1F7E911000A187E9 /* NSUnarchiver+Extension.m */,
+				4E6C521B1F7E911000A187E9 /* NSUserDefaults+Extension.h */,
+				4E6C521C1F7E911000A187E9 /* NSUserDefaults+Extension.m */,
+				4E6C521D1F7E911000A187E9 /* NSView+Extension.h */,
+				4E6C521E1F7E911000A187E9 /* NSView+Extension.m */,
+				4EA69BD21FC8DDEA00C70100 /* NSWorkspace+Extension.h */,
+				4EA69BD31FC8DDEA00C70100 /* NSWorkspace+Extension.m */,
+			);
+			name = Extensions;
+			sourceTree = "<group>";
+		};
+		4E6C525A1F7E943900A187E9 /* Legacy */ = {
+			isa = PBXGroup;
+			children = (
+				4E6C525B1F7E944F00A187E9 /* SZJsonParser.h */,
+				4E6C525C1F7E944F00A187E9 /* SZJsonParser.m */,
+			);
+			name = Legacy;
+			sourceTree = "<group>";
+		};
+		4E6C52601F7E950900A187E9 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				4E6C52611F7E953A00A187E9 /* NKFTPManager.h */,
+				4E6C52621F7E953A00A187E9 /* NKFTPManager.m */,
+				4E7D41B721665F2C001BEADB /* VMMVideoCardManager.h */,
+				4E7D41B821665F2C001BEADB /* VMMVideoCardManager.m */,
+				4EE52845205EC3560005F335 /* VMMVideoCard.h */,
+				4EE52846205EC3560005F335 /* VMMVideoCard.m */,
+				4E6C526F1F7E954D00A187E9 /* VMMComputerInformation.h */,
+				4E6C52701F7E954D00A187E9 /* VMMComputerInformation.m */,
+				4E0DD3B81FD878F90033AA72 /* VMMLocalizationUtility.h */,
+				4E6C52631F7E953A00A187E9 /* VMMLogUtility.h */,
+				4EFA51951FE9710B002D68FC /* VMMLogUtility.m */,
+				4EF16B1D1F8E36A600A78DC0 /* VMMModals.h */,
+				4EF16B1E1F8E36A600A78DC0 /* VMMModals.m */,
+				4ECB93A420289E4B00F0A369 /* VMMParentalControls.h */,
+				4ECB93A520289E4B00F0A369 /* VMMParentalControls.m */,
+				4E37704920517EB300AADB8A /* VMMPropertyList.h */,
+				4E37704A20517EB300AADB8A /* VMMPropertyList.m */,
+				4E6C52641F7E953A00A187E9 /* VMMUserNotificationCenter.h */,
+				4E6C52651F7E953A00A187E9 /* VMMUserNotificationCenter.m */,
+				4E3BD7011FAD2FCF00AF8418 /* VMMUUID.h */,
+				4E3BD7021FAD2FCF00AF8418 /* VMMUUID.m */,
+				4E6C52661F7E953A00A187E9 /* VMMVersion.h */,
+				4E6C52671F7E953A00A187E9 /* VMMVersion.m */,
+			);
+			name = Utilities;
+			sourceTree = "<group>";
+		};
+		4E6C52731F7E9D6400A187E9 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				4E9C67642180C43800F6C17E /* Metal.framework */,
+				4E4CD93720897CF5008CF4F7 /* OpenGL.framework */,
+				4E6C527C1F7E9E4C00A187E9 /* Carbon.framework */,
+				4E6C527A1F7E9E4000A187E9 /* CoreImage.framework */,
+				4E6C52781F7E9E1400A187E9 /* IOKit.framework */,
+				4E6C52761F7E9D6D00A187E9 /* Foundation.framework */,
+				4E6C52741F7E9D6400A187E9 /* Cocoa.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		4E6C527E1F7EA3E500A187E9 /* Functions */ = {
+			isa = PBXGroup;
+			children = (
+				4E6C52851F7EA42700A187E9 /* NSArrayTests.m */,
+				4EAD49241FBBB5AE008B562F /* NSColorTests.m */,
+				4E6C52861F7EA42700A187E9 /* NSStringTests.m */,
+			);
+			name = Functions;
+			sourceTree = "<group>";
+		};
+		4EA035A51F9532C80059C2C5 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				4E6C51F11F7E911000A187E9 /* VMMAlert.h */,
+				4E6C51F21F7E911000A187E9 /* VMMAlert.m */,
+				4E5A45D71FC9FD7800FCEB42 /* VMMDockProgressIndicator.h */,
+				4E5A45D81FC9FD7800FCEB42 /* VMMDockProgressIndicator.m */,
+				4EA035A61F9532E10059C2C5 /* VMMKeyCaptureField.h */,
+				4EA035A71F9532E10059C2C5 /* VMMKeyCaptureField.m */,
+				4E2462F12207793F00E5C02B /* VMMMenu.h */,
+				4E2462F22207793F00E5C02B /* VMMMenu.m */,
+				4EB392DF1FC479060098F987 /* VMMTextFileView.h */,
+				4EB392E01FC479060098F987 /* VMMTextFileView.m */,
+				4E1181571FB200E800D8029F /* VMMView.h */,
+				4E1181581FB200E800D8029F /* VMMView.m */,
+				4E3771041FA7A57C00E2F511 /* VMMWebView.h */,
+				4E3771051FA7A57C00E2F511 /* VMMWebView.m */,
+			);
+			name = Views;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		4E6C51041F7E8EB700A187E9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4E66CA72214D54CF004293A5 /* ObjCExtensionConfig.h in Headers */,
+				4E6C521F1F7E911000A187E9 /* VMMAlert.h in Headers */,
+				4E9986701FEEC85600E434E4 /* NSApplication+Extension.h in Headers */,
+				4E6C52211F7E911000A187E9 /* NSArray+Extension.h in Headers */,
+				4E6C52231F7E911000A187E9 /* NSAttributedString+Extension.h in Headers */,
+				4E5A45DD1FCA103800FCEB42 /* NSBundle+Extension.h in Headers */,
+				4E6C52251F7E911000A187E9 /* NSColor+Extension.h in Headers */,
+				4E6C52271F7E911000A187E9 /* NSData+Extension.h in Headers */,
+				4E6C52291F7E911000A187E9 /* NSDateFormatter+Extension.h in Headers */,
+				4EFA51931FE96C8C002D68FC /* NSException+Extension.h in Headers */,
+				4E6C522B1F7E911000A187E9 /* NSFileManager+Extension.h in Headers */,
+				4E6C522D1F7E911000A187E9 /* NSImage+Extension.h in Headers */,
+				4E6C52311F7E911000A187E9 /* NSMenuItem+Extension.h in Headers */,
+				4E6C52331F7E911000A187E9 /* NSMutableArray+Extension.h in Headers */,
+				4E6C52351F7E911000A187E9 /* NSMutableAttributedString+Extension.h in Headers */,
+				4E6C52371F7E911000A187E9 /* NSMutableDictionary+Extension.h in Headers */,
+				4EEBF4701FAE238F00CE31A0 /* NSMutableString+Extension.h in Headers */,
+				4E6C52391F7E911000A187E9 /* NSMutableURLRequest+Extension.h in Headers */,
+				4E6C523B1F7E911000A187E9 /* NSRunningApplication+Extension.h in Headers */,
+				4E6C523D1F7E911000A187E9 /* NSSavePanel+Extension.h in Headers */,
+				4E53A8A61F8587D90038BDFE /* NSScreen+Extension.h in Headers */,
+				4E6C523F1F7E911000A187E9 /* NSString+Extension.h in Headers */,
+				4E6C52411F7E911000A187E9 /* NSTask+Extension.h in Headers */,
+				4E6C52431F7E911000A187E9 /* NSText+Extension.h in Headers */,
+				4E0DE40E1FC703A2004AA363 /* NSTimer+Extension.h in Headers */,
+				4E6C52451F7E911000A187E9 /* NSThread+Extension.h in Headers */,
+				4E6C52471F7E911000A187E9 /* NSUnarchiver+Extension.h in Headers */,
+				4E6C52491F7E911000A187E9 /* NSUserDefaults+Extension.h in Headers */,
+				4E6C524B1F7E911000A187E9 /* NSView+Extension.h in Headers */,
+				4EA69BD41FC8DDEA00C70100 /* NSWorkspace+Extension.h in Headers */,
+				4E6C52711F7E954D00A187E9 /* VMMComputerInformation.h in Headers */,
+				4E6C51EC1F7E90A300A187E9 /* VMMDeviceObserver.h in Headers */,
+				4E231F931F8191DD00148A30 /* VMMDeviceSimulator.h in Headers */,
+				4E5A45D91FC9FD7800FCEB42 /* VMMDockProgressIndicator.h in Headers */,
+				4EA035A81F9532E10059C2C5 /* VMMKeyCaptureField.h in Headers */,
+				4E34B2F41FD879DE001F0B4F /* VMMLocalizationUtility.h in Headers */,
+				4E6C526A1F7E953A00A187E9 /* VMMLogUtility.h in Headers */,
+				4EF16B1F1F8E36A600A78DC0 /* VMMModals.h in Headers */,
+				4ECB93A620289E4B00F0A369 /* VMMParentalControls.h in Headers */,
+				4E37704B20517EB300AADB8A /* VMMPropertyList.h in Headers */,
+				4EB392E11FC479060098F987 /* VMMTextFileView.h in Headers */,
+				4E6C51EE1F7E90A300A187E9 /* VMMUsageKeycode.h in Headers */,
+				4E6C526B1F7E953A00A187E9 /* VMMUserNotificationCenter.h in Headers */,
+				4E3BD7031FAD2FCF00AF8418 /* VMMUUID.h in Headers */,
+				4E6C526D1F7E953A00A187E9 /* VMMVersion.h in Headers */,
+				4EE52847205EC3560005F335 /* VMMVideoCard.h in Headers */,
+				4E2462F32207793F00E5C02B /* VMMMenu.h in Headers */,
+				4E7D41B921665F2C001BEADB /* VMMVideoCardManager.h in Headers */,
+				4E1181591FB200E800D8029F /* VMMView.h in Headers */,
+				4E6C51EA1F7E90A300A187E9 /* VMMVirtualKeycode.h in Headers */,
+				4E3771061FA7A57C00E2F511 /* VMMWebView.h in Headers */,
+				4E6C52681F7E953A00A187E9 /* NKFTPManager.h in Headers */,
+				4E6C51181F7E8EB700A187E9 /* ObjectiveC_Extension.h in Headers */,
+				4E6C525D1F7E944F00A187E9 /* SZJsonParser.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		4E6C51061F7E8EB700A187E9 /* ObjectiveC_Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4E6C511B1F7E8EB700A187E9 /* Build configuration list for PBXNativeTarget "ObjectiveC_Extension" */;
+			buildPhases = (
+				4E6C51021F7E8EB700A187E9 /* Sources */,
+				4E6C51031F7E8EB700A187E9 /* Frameworks */,
+				4E6C51041F7E8EB700A187E9 /* Headers */,
+				4E6C51051F7E8EB700A187E9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ObjectiveC_Extension;
+			productName = ObjectiveC_Extension;
+			productReference = 4E6C51071F7E8EB700A187E9 /* ObjectiveC_Extension.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		4E6C510F1F7E8EB700A187E9 /* ObjectiveC_ExtensionTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4E6C511E1F7E8EB700A187E9 /* Build configuration list for PBXNativeTarget "ObjectiveC_ExtensionTests" */;
+			buildPhases = (
+				4E6C510C1F7E8EB700A187E9 /* Sources */,
+				4E6C510D1F7E8EB700A187E9 /* Frameworks */,
+				4E6C510E1F7E8EB700A187E9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4E6C51131F7E8EB700A187E9 /* PBXTargetDependency */,
+			);
+			name = ObjectiveC_ExtensionTests;
+			productName = ObjectiveC_ExtensionTests;
+			productReference = 4E6C51101F7E8EB700A187E9 /* ObjectiveC_ExtensionTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		4E6C50FE1F7E8EB700A187E9 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0930;
+				ORGANIZATIONNAME = VitorMM;
+				TargetAttributes = {
+					4E6C51061F7E8EB700A187E9 = {
+						CreatedOnToolsVersion = 8.3.3;
+						DevelopmentTeam = 45WEPZ3433;
+						ProvisioningStyle = Automatic;
+					};
+					4E6C510F1F7E8EB700A187E9 = {
+						CreatedOnToolsVersion = 8.3.3;
+						DevelopmentTeam = 45WEPZ3433;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 4E6C51011F7E8EB700A187E9 /* Build configuration list for PBXProject "ObjectiveC_Extension" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				English,
+				en,
+				nl,
+				de,
+				"pt-BR",
+				fr,
+			);
+			mainGroup = 4E6C50FD1F7E8EB700A187E9;
+			productRefGroup = 4E6C51081F7E8EB700A187E9 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				4E6C51061F7E8EB700A187E9 /* ObjectiveC_Extension */,
+				4E6C510F1F7E8EB700A187E9 /* ObjectiveC_ExtensionTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		4E6C51051F7E8EB700A187E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4E6C52941F7EB50300A187E9 /* Localizable.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4E6C510E1F7E8EB700A187E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		4E6C51021F7E8EB700A187E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4E6C52281F7E911000A187E9 /* NSData+Extension.m in Sources */,
+				4E6C52441F7E911000A187E9 /* NSText+Extension.m in Sources */,
+				4E5A45DE1FCA103800FCEB42 /* NSBundle+Extension.m in Sources */,
+				4E6C526C1F7E953A00A187E9 /* VMMUserNotificationCenter.m in Sources */,
+				4E3BD7041FAD2FCF00AF8418 /* VMMUUID.m in Sources */,
+				4E6C52261F7E911000A187E9 /* NSColor+Extension.m in Sources */,
+				4EF16B201F8E36A600A78DC0 /* VMMModals.m in Sources */,
+				4EA69BD51FC8DDEA00C70100 /* NSWorkspace+Extension.m in Sources */,
+				4E6C523C1F7E911000A187E9 /* NSRunningApplication+Extension.m in Sources */,
+				4E6C522C1F7E911000A187E9 /* NSFileManager+Extension.m in Sources */,
+				4E6C52381F7E911000A187E9 /* NSMutableDictionary+Extension.m in Sources */,
+				4E0DE40F1FC703A2004AA363 /* NSTimer+Extension.m in Sources */,
+				4E11815A1FB200E800D8029F /* VMMView.m in Sources */,
+				4E6C522E1F7E911000A187E9 /* NSImage+Extension.m in Sources */,
+				4E6C52461F7E911000A187E9 /* NSThread+Extension.m in Sources */,
+				4EB392E21FC479060098F987 /* VMMTextFileView.m in Sources */,
+				4EFA51941FE96C8C002D68FC /* NSException+Extension.m in Sources */,
+				4E6C524A1F7E911000A187E9 /* NSUserDefaults+Extension.m in Sources */,
+				4E6C51EB1F7E90A300A187E9 /* VMMVirtualKeycode.m in Sources */,
+				4E6C523E1F7E911000A187E9 /* NSSavePanel+Extension.m in Sources */,
+				4E6C523A1F7E911000A187E9 /* NSMutableURLRequest+Extension.m in Sources */,
+				4E6C52481F7E911000A187E9 /* NSUnarchiver+Extension.m in Sources */,
+				4E6C52341F7E911000A187E9 /* NSMutableArray+Extension.m in Sources */,
+				4E3771071FA7A57C00E2F511 /* VMMWebView.m in Sources */,
+				4E6C52321F7E911000A187E9 /* NSMenuItem+Extension.m in Sources */,
+				4E2462F42207793F00E5C02B /* VMMMenu.m in Sources */,
+				4E9986711FEEC85600E434E4 /* NSApplication+Extension.m in Sources */,
+				4E6C52691F7E953A00A187E9 /* NKFTPManager.m in Sources */,
+				4E6C52721F7E954D00A187E9 /* VMMComputerInformation.m in Sources */,
+				4E7D41BA21665F2C001BEADB /* VMMVideoCardManager.m in Sources */,
+				4E6C52361F7E911000A187E9 /* NSMutableAttributedString+Extension.m in Sources */,
+				4E6C52221F7E911000A187E9 /* NSArray+Extension.m in Sources */,
+				4E6C51ED1F7E90A300A187E9 /* VMMDeviceObserver.m in Sources */,
+				4E6C52421F7E911000A187E9 /* NSTask+Extension.m in Sources */,
+				4E231F941F8191DD00148A30 /* VMMDeviceSimulator.m in Sources */,
+				4ECB93A720289E4B00F0A369 /* VMMParentalControls.m in Sources */,
+				4EEBF4711FAE238F00CE31A0 /* NSMutableString+Extension.m in Sources */,
+				4E53A8A71F8587D90038BDFE /* NSScreen+Extension.m in Sources */,
+				4E6C51EF1F7E90A300A187E9 /* VMMUsageKeycode.m in Sources */,
+				4E6C52401F7E911000A187E9 /* NSString+Extension.m in Sources */,
+				4EFA51961FE9710B002D68FC /* VMMLogUtility.m in Sources */,
+				4EE52848205EC3560005F335 /* VMMVideoCard.m in Sources */,
+				4EA035A91F9532E10059C2C5 /* VMMKeyCaptureField.m in Sources */,
+				4E6C522A1F7E911000A187E9 /* NSDateFormatter+Extension.m in Sources */,
+				4E6C52201F7E911000A187E9 /* VMMAlert.m in Sources */,
+				4E6C524C1F7E911000A187E9 /* NSView+Extension.m in Sources */,
+				4E6C52241F7E911000A187E9 /* NSAttributedString+Extension.m in Sources */,
+				4E6C526E1F7E953A00A187E9 /* VMMVersion.m in Sources */,
+				4E6C525E1F7E944F00A187E9 /* SZJsonParser.m in Sources */,
+				4E5A45DA1FC9FD7800FCEB42 /* VMMDockProgressIndicator.m in Sources */,
+				4E37704C20517EB300AADB8A /* VMMPropertyList.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4E6C510C1F7E8EB700A187E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4EAD49251FBBB5AE008B562F /* NSColorTests.m in Sources */,
+				4E6C52881F7EA42700A187E9 /* NSArrayTests.m in Sources */,
+				4E6C52891F7EA42700A187E9 /* NSStringTests.m in Sources */,
+				4E6C51161F7E8EB700A187E9 /* ObjectiveC_ExtensionTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		4E6C51131F7E8EB700A187E9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4E6C51061F7E8EB700A187E9 /* ObjectiveC_Extension */;
+			targetProxy = 4E6C51121F7E8EB700A187E9 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		4E6C52961F7EB50300A187E9 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				4E6C52951F7EB50300A187E9 /* en */,
+				4E6C52971F7EB51D00A187E9 /* nl */,
+				4E6C52981F7EB52100A187E9 /* de */,
+				4E6C52991F7EB52500A187E9 /* pt-BR */,
+				4E6C529A1F7EB52A00A187E9 /* fr */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		4E6C51191F7E8EB700A187E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		4E6C511A1F7E8EB700A187E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				ONLY_ACTIVE_ARCH = NO;
+				SDKROOT = macosx;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		4E6C511C1F7E8EB700A187E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 45WEPZ3433;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = ObjectiveC_Extension/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					Metal,
+					"-weak_framework",
+					OpenGL,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vitormm.ObjectiveC-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		4E6C511D1F7E8EB700A187E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 45WEPZ3433;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = ObjectiveC_Extension/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					Metal,
+					"-weak_framework",
+					OpenGL,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vitormm.ObjectiveC-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		4E6C511F1F7E8EB700A187E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 45WEPZ3433;
+				INFOPLIST_FILE = ObjectiveC_ExtensionTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vitormm.ObjectiveC-ExtensionTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		4E6C51201F7E8EB700A187E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 45WEPZ3433;
+				INFOPLIST_FILE = ObjectiveC_ExtensionTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vitormm.ObjectiveC-ExtensionTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		4E6C51011F7E8EB700A187E9 /* Build configuration list for PBXProject "ObjectiveC_Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4E6C51191F7E8EB700A187E9 /* Debug */,
+				4E6C511A1F7E8EB700A187E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4E6C511B1F7E8EB700A187E9 /* Build configuration list for PBXNativeTarget "ObjectiveC_Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4E6C511C1F7E8EB700A187E9 /* Debug */,
+				4E6C511D1F7E8EB700A187E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4E6C511E1F7E8EB700A187E9 /* Build configuration list for PBXNativeTarget "ObjectiveC_ExtensionTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4E6C511F1F7E8EB700A187E9 /* Debug */,
+				4E6C51201F7E8EB700A187E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 4E6C50FE1F7E8EB700A187E9 /* Project object */;
+}

--- a/ObjectiveC_Extension/ObjectiveC_Extension.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ObjectiveC_Extension/ObjectiveC_Extension.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:ObjectiveC_Extension.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/ObjectiveC_Extension/ObjectiveC_Extension.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ObjectiveC_Extension/ObjectiveC_Extension.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ObjectiveC_Extension/ObjectiveC_Extension.xcodeproj/xcshareddata/xcschemes/ObjectiveC_Extension.xcscheme
+++ b/ObjectiveC_Extension/ObjectiveC_Extension.xcodeproj/xcshareddata/xcschemes/ObjectiveC_Extension.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4E6C51061F7E8EB700A187E9"
+               BuildableName = "ObjectiveC_Extension.framework"
+               BlueprintName = "ObjectiveC_Extension"
+               ReferencedContainer = "container:ObjectiveC_Extension.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4E6C510F1F7E8EB700A187E9"
+               BuildableName = "ObjectiveC_ExtensionTests.xctest"
+               BlueprintName = "ObjectiveC_ExtensionTests"
+               ReferencedContainer = "container:ObjectiveC_Extension.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4E6C51061F7E8EB700A187E9"
+            BuildableName = "ObjectiveC_Extension.framework"
+            BlueprintName = "ObjectiveC_Extension"
+            ReferencedContainer = "container:ObjectiveC_Extension.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4E6C51061F7E8EB700A187E9"
+            BuildableName = "ObjectiveC_Extension.framework"
+            BlueprintName = "ObjectiveC_Extension"
+            ReferencedContainer = "container:ObjectiveC_Extension.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4E6C51061F7E8EB700A187E9"
+            BuildableName = "ObjectiveC_Extension.framework"
+            BlueprintName = "ObjectiveC_Extension"
+            ReferencedContainer = "container:ObjectiveC_Extension.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ObjectiveC_Extension/ObjectiveC_Extension/CREDITS
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/CREDITS
@@ -1,0 +1,34 @@
+DEVELOPMENT
+
+Vitor Marques de Miranda (vitor251093)
+
+
+NKFTPMANAGER DEVELOPMENT
+
+Nico Kreipke (nkreipke)
+
+
+LOCALIZATION
+
+English
+Vitor Marques de Miranda (vitor251093)
+
+English Revision
+Jean Baumgarten
+Paul Bertelink (PaulTheTall)
+
+Portuguese
+Vitor Marques de Miranda (vitor251093)
+
+Dutch
+Paul Bertelink (PaulTheTall)
+
+German
+Sascha Lamprecht (Sascha_77)
+Jean Baumgarten
+
+French
+Samuel Gauthier
+
+French Revision
+Jean Baumgarten

--- a/ObjectiveC_Extension/ObjectiveC_Extension/Info.plist
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2017 VitorMM. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NKFTPManager.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NKFTPManager.h
@@ -1,0 +1,378 @@
+//
+//  NKFTPManager.h
+//  FTPManager
+//
+//  Created by Nico Kreipke on 11.08.11.
+//  Copyright (c) 2014 nkreipke. All rights reserved.
+//  http://nkreipke.de
+//
+
+//  Version 1.6.5
+//  SEE LICENSE FILE FOR LICENSE INFORMATION
+
+// Information:
+// Parts of this class are based on the SimpleFTPSample sample code by Apple.
+
+// This class requires the following frameworks:
+// - CoreServices.framework (OS X)
+// - CFNetwork.framework (iOS)
+
+// ***********
+// CHANGELOG**
+// ***********
+//
+// ** 1.2 (2012-05-28) by nkreipke
+//     - Methods added:
+//         - (float) progress
+//         - (void)  abort
+//     - downloadFile:toDirectory:fromServer: now sends an FTP STAT command to
+//         determine the size of the file to download.
+//
+// ** 1.3 (2012-05-28) by jweinert (cs&m GmbH)
+//     - Protocol declaration added:
+//         FTPManagerDelegate
+//     - Delegate Methods added (both optional):
+//         - (void)FTPManagerUploadProgressDidChange:(NSDictionary *)upInfo
+//         - (void)FTPManagerDownloadProgressDidChange:(NSDictionary *)downInfo
+//              Both methods return an NSDictionary providing the following information (keys):
+//                  * progress:             progress (0.0f to 1.0f, -1.0 at fail)
+//                  * fileSize:             size of the currently processing file
+//                  * bytesProcessed:       number of Bytes processed from the current session
+//                  * fileSizeProcessed:    number of Bytes processed of the currently processing file
+//
+// ** 1.4 (2012-06-07) by jweinert (cs&m GmbH)
+//     - Methods added:
+//         - uploadData:withFileName:toServer:
+//         - deleteFile:fromServer:
+//
+// ** 1.4.1 (2012-06-08) by nkreipke
+//     - replaced string keys with kFMProcessInfo constants.
+//     - changed method declarations containing an info dictionary to name it processInfo.
+//     - fixed broken createNewFolder method in ARC version
+//
+// ** 1.5 (2012-10-25) by nkreipke
+//     - FMServer:
+//         + anonymousServerWithDestination:(NSURL*)
+//     - added NSURL category FTPManagerNSURLAdditions
+//     - the destination URL does NOT need the "ftp://" prefix anymore
+//     - deleteFile:fromServer: is deprecated
+//     - Methods added:
+//         - deleteFileNamed:fromServer:
+//         - chmodFileNamed:to:atServer:
+//         - checkLogin:
+//     - cleaned up the code a little
+//
+// ** 1.6 (2013-01-13) by nkreipke
+//     - FMServer:
+//         - fixed a bug where variables were not retained properly
+//         - FMServer.destination is now NSString! You will have to change that in your code.
+//         - In FMSever.port the port can be specified. This is 21 by default.
+//     - fixed a bug where an empty file was created if downloadFile was not successful
+//
+// ** (1.6.1 -> release for CocoaPods)
+//
+// ** 1.6.2 (2013-04-24) by nkreipke
+//     - fixed a bug that occured in iOS 6 (https://github.com/nkreipke/FTPManager/issues/5)
+//     - fixed garbage value bug
+//
+// ** 1.6.3 (2014-01-25) by nkreipke
+//     - fixed a memory leak
+//
+// ** 1.6.4 (2014-06-13) by nkreipke
+//     - fixed crash that can occur when scheduling the stream (thanks to Kevin Paunovic)
+//     - fixed race condition bug while aborting
+//     - a separate NSThread is now used instead of using whatever thread FTPManager was called on
+//     - fixed bug that prevented subdirectories from being accessed when port was not 21
+//     - fixed bug that prevented subdirectories with names containing spaces from being accessed
+//
+// ** 1.6.5 (2014-08-12) by nkreipke
+//     - kCFFTPResourceName entry is now converted into UTF8 encoding to cope with Non-ASCII characters
+//
+
+// SCROLL DOWN TO SEE THE WELL COMMENTED PUBLIC METHODS. *****************
+
+// LOOK AT FTPMSample1.m FOR AN EXAMPLE HOW TO USE THIS CLASS. ***********
+
+
+#import <Foundation/Foundation.h>
+#import <sys/socket.h>
+#import <sys/types.h>
+#import <netinet/in.h>
+#import <netdb.h>
+
+//FTPManager can log Socket answers if you got problems with
+//deletion and chmod:
+//#define FMSOCKET_VERBOSE
+
+//these are used internally:
+#define FTPANONYMOUS @"anonymous"
+/*enum {
+ kFTPAnswerSuccess = 200,
+ kFTPAnswerLoggedIn = 230,
+ kFTPAnswerFileActionOkay = 250,
+ kFTPAnswerNeedsPassword = 331,
+ kFTPAnswerNotAvailable = 421,
+ kFTPAnswerNotLoggedIn = 530
+ };*/
+
+@interface FMServer : NSObject {
+@private
+    NSString* destination;
+    NSString* password;
+    NSString* username;
+    int port;
+}
+
+/**
+ *  The URL of the FMServer.
+ */
+@property (strong) NSString* destination;
+
+/**
+ *  The password for the FMServer login.
+ */
+@property (strong) NSString* password;
+
+/**
+ *  The username for the FMServer login.
+ */
+@property (strong) NSString* username;
+
+/**
+ *  The port which is used for the connection.
+ */
+@property  (unsafe_unretained) int port;
+
+/**
+ *  Returns a FMServer initialized with the given URL and credentials.
+ *
+ *  @param dest The URL of the FTP server.
+ *  @param user The username of the account which will be used to log in.
+ *  @param pass The password which will be used to log in.
+ *
+ *  @return A FMServer object with the given URL, username and password.
+ */
++ (FMServer*) serverWithDestination:(NSString*)dest username:(NSString*)user password:(NSString*)pass;
+
+/**
+ *  Returns a FMServer initialized with the given URL and anonymous login.
+ *
+ *  @param dest The URL of the FTP server.
+ *
+ *  @return A FMServer object with the given URL and anonymous login.
+ */
++ (FMServer*) anonymousServerWithDestination:(NSString*)dest;
+
+@end
+
+@interface NSString (FTPManagerNSStringAdditions)
+-(NSString*)stringWithoutProtocol;
+-(NSURL*)ftpURLForPort:(int)port;
+-(NSString*)fmhost;
+-(NSString*)fmdir;
+@end
+
+enum {
+    kSendBufferSize = 32768
+};
+
+typedef enum {
+    FMStreamFailureReasonNone,
+    FMStreamFailureReasonReadError,
+    FMStreamFailureReasonWriteError,
+    FMStreamFailureReasonGeneralError,
+    FMStreamFailureReasonAborted
+} FMStreamFailureReason;
+
+typedef enum {
+    _FMCurrentActionUploadFile,
+    _FMCurrentActionCreateNewFolder,
+    _FMCurrentActionContentsOfServer,
+    _FMCurrentActionDownloadFile,
+    _FMCurrentActionSOCKET,
+    _FMCurrentActionNone
+} _FMCurrentAction;
+
+/* I do not recommend to use this delegate, because the methods will slow down
+ * the process. On top of this they may have some threading issues that could
+ * be pretty confusing. Use an NSTimer and [manager progress] instead. */
+@protocol NKFTPManagerDelegate <NSObject>
+@optional
+- (void)ftpManagerUploadProgressDidChange:(NSDictionary *)processInfo;
+// Returns information about the current upload.
+// See "Process Info Dictionary Constants" below for detailed info.
+- (void)ftpManagerDownloadProgressDidChange:(NSDictionary *)processInfo;
+// Returns information about the current download.
+// See "Process Info Dictionary Constants" below for detailed info.
+@end
+
+#pragma mark - Process Info Dictionary Constants
+
+// Process Info Dictionary Constants (for [manager progress]): ******************
+#define kFMProcessInfoProgress @"progress" // 0.0 to 1.0
+#define kFMProcessInfoFileSize @"fileSize"
+#define kFMProcessInfoBytesProcessed @"bytesProcessed"
+#define kFMProcessInfoFileSizeProcessed @"fileSizeProcessed"
+// ---------------------------------(returns NSNumber values)--------------------
+
+#pragma mark -
+
+@interface NKFTPManager : NSObject <NSStreamDelegate> {
+    CFRunLoopRef currentRunLoop;
+    
+    _FMCurrentAction action;
+    
+    uint8_t _buffer[kSendBufferSize];
+    size_t _bufferOffset;
+    size_t _bufferLimit;
+    
+    unsigned long long fileSize;
+    unsigned long long bytesProcessed;
+    unsigned long long fileSizeProcessed;
+    
+    BOOL streamSuccess;
+}
+
+/**
+ *  Input steam for reading from a local file
+ */
+@property (strong) NSInputStream *fileReader;
+
+/**
+ *  Output stream for writing to a local file
+ */
+@property (strong) NSOutputStream *fileWriter;
+
+/**
+ *  Input stream for reading from the server (remote file)
+ */
+@property (strong) NSInputStream *serverReadStream;
+
+/**
+ *  Output stream for writing to the server (remote file)
+ */
+@property (strong) NSOutputStream *serverStream;
+
+@property (strong) NSMutableData *directoryListingData;
+
+
+@property (assign) id<NKFTPManagerDelegate>delegate;
+
+#pragma mark - Public Methods
+
+// *** Information
+// These methods hold the current thread. You will get an answer with a success information.
+
+/**
+ *  Uploads a file to a server. Existing remote files of the same name will be overwritten.
+ *
+ *  @param fileURL The local file which will be uploaded to the FTP server.
+ *  @param server  The FTP server which the file will be uploaded to.
+ *
+ *  @return YES if the upload was successful, NO otherwise.
+ */
+- (BOOL) uploadFile:(NSURL*)fileURL toServer:(FMServer*)server;
+
+/**
+ *  Uploads NSData to a server. Existing remote files of the same name will be overwritten.
+ *
+ *  @param data     The data which will be written to the FTP server.
+ *  @param fileName The name with which the new file will be created on the FTP server.
+ *  @param server   The FTP server on which the file with the given data will be created.
+ *
+ *  @return YES if the upload was successful, NO otherwise.
+ */
+- (BOOL) uploadData:(NSData*)data withFileName:(NSString *)fileName toServer:(FMServer*)server;
+
+/**
+ *  Creates a new folder on the specified FTP server.
+ *
+ *  @param folderName The name of the folder to create.
+ *  @param server     The FTP server on which the new folder should be created.
+ *
+ *  @return YES if the folder creation was successful, NO otherwise.
+ */
+- (BOOL) createNewFolder:(NSString*)folderName atServer:(FMServer*)server;
+
+/**
+ *  Returns a list of files and folders at the specified FTP server. as an NSArray containing instances of NSDictionary.
+ *  The dictionaries contain objects declared in CFStream FTP Resource Constants. To get the name of the entry, get the object for the (id)kCFFTPResourceName key.
+ *
+ *  @param server The FTP server whose contents will be listed.
+ *
+ *  @return The NSArray containing instances of NSDictionary. An empty array if the server has no contents. nil if there was an error during the process.
+ */
+- (NSArray*) contentsOfServer:(FMServer*)server;
+
+/**
+ *  Downloads a file from the specified FTP server. Existing local files of the same name will be overwritten.
+ *
+ *  @param fileName     The file which will be downloaded from the specified FTP server.
+ *  @param directoryURL The local directory the file will be downloaded to.
+ *  @param server       The server the file will be downloaded from.
+ *
+ *  @return YES if the download was successful, NO otherwise
+ */
+- (BOOL) downloadFile:(NSString*)fileName toDirectory:(NSURL*)directoryURL fromServer:(FMServer*)server;
+
+/**
+ *  Delete a file from the specified FTP server and delete directories if they are empty.
+ *
+ *  @param fileName The file which will be deleted from the FTP server.
+ *  @param server   The FTP server from which the file or directory will be deleted.
+ *
+ *  @return YES if the file was successfully deleted from the server, NO otherwise.
+ */
+- (BOOL) deleteFileNamed:(NSString*)fileName fromServer:(FMServer*)server;
+
+/**
+ *  Changes the mode of a file on a server. Works only on UNIX servers.
+ *
+ *  @param fileName The file whose permissions will be modified.
+ *  @param mode     The mode which will be applied to the remote file in octal notation.
+ *  @param server   The server on which the mode change operation will take place.
+ *
+ *  @return YES if the chmod command was successful, NO otherwise.
+ */
+- (BOOL) chmodFileNamed:(NSString*)fileName to:(int)mode atServer:(FMServer*)server;
+
+/**
+ *  Logs into the FTP server and logs out again. This can be used to check whether the credentials are correct before trying to do a file operation.
+ *
+ *  @param server The FMServer FTP object to log into.
+ *
+ *  @return YES if the login was successful, NO otherwise.
+ */
+- (BOOL) checkLogin:(FMServer*)server;
+
+/**
+ *  Returns information about the current process. As the FTP methods hold the thread, you may want to call this method from a different thread that updates the UI.
+ *  See 'Process Info Dictionary Constants' above for information about the contents of the dictionary.
+ *
+ *  @return nil if no process is currently running or information could not be determined. This method only works when downloading or uploading a file.
+ */
+- (NSMutableDictionary *) progress;
+
+/**
+ *  Aborts the current process. As the FTP methods hold the thread, you may want to call this method from a different thread.
+ */
+- (void) abort;
+
+
+
+
+
+//deprecated:
+/**
+ *  Deletes a file or directory from the specified FTP server. Uses absolute path on server as path parameter.
+ *  DEPRECATED: Use deleteFileNamed:fromServer: instead.
+ *
+ *  @param absolutePath The absolute path to the file which will be deleted on the server. The URL must end with a slash ("/").
+ *  @param server       The server from which the file will be deleted.
+ *
+ *  @return YES if the file was successfully deleted, NO otherwise.
+ */
+- (BOOL) deleteFile:(NSString *)absolutePath fromServer:(FMServer *)server DEPRECATED_ATTRIBUTE;
+
+@end
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NKFTPManager.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NKFTPManager.m
@@ -1,0 +1,973 @@
+//http://nkreipke.wordpress.com/2011/08/11/ftpmanager-eine-objective-c-klasse-zum-verwenden-von-ftp/
+
+//
+//  NKFTPManager.m
+//  FTPManager
+//
+//  Created by Nico Kreipke on 11.08.11.
+//  Copyright (c) 2014 nkreipke. All rights reserved.
+//  http://nkreipke.de
+//
+
+//  Version 1.6.5
+//  SEE LICENSE FILE FOR LICENSE INFORMATION
+
+// Information:
+// Parts of this class are based on the SimpleFTPSample sample code by Apple.
+
+// This class requires the following frameworks:
+// - CoreServices.framework (OS X)
+// - CFNetwork.framework (iOS)
+
+// ***********
+// CHANGELOG**
+// ***********
+//
+// ** 1.2 (2012-05-28) by nkreipke
+//     - Methods added:
+//         - (float) progress
+//         - (void)  abort
+//     - downloadFile:toDirectory:fromServer: now sends an FTP STAT command to
+//         determine the size of the file to download.
+//
+// ** 1.3 (2012-05-28) by jweinert (cs&m GmbH)
+//     - Protocol declaration added:
+//         FTPManagerDelegate
+//     - Delegate Methods added (both optional):
+//         - (void)FTPManagerUploadProgressDidChange:(NSDictionary *)upInfo
+//         - (void)FTPManagerDownloadProgressDidChange:(NSDictionary *)downInfo
+//              Both methods return an NSDictionary providing the following information (keys):
+//                  * progress:             progress (0.0f to 1.0f, -1.0 at fail)
+//                  * fileSize:             size of the currently processing file
+//                  * bytesProcessed:       number of Bytes processed from the current session
+//                  * fileSizeProcessed:    number of Bytes processed of the currently processing file
+//
+// ** 1.4 (2012-06-07) by jweinert (cs&m GmbH)
+//     - Methods added:
+//         - uploadData:withFileName:toServer:
+//         - deleteFile:fromServer:
+//
+// ** 1.4.1 (2012-06-08) by nkreipke
+//     - replaced string keys with kFMProcessInfo constants.
+//     - changed method declarations containing an info dictionary to name it processInfo.
+//     - fixed broken createNewFolder method in ARC version
+//
+// ** 1.5 (2012-10-25) by nkreipke
+//     - FMServer:
+//         + anonymousServerWithDestination:(NSURL*)
+//     - added NSURL category FTPManagerNSURLAdditions
+//     - the destination URL does NOT need the "ftp://" prefix anymore
+//     - deleteFile:fromServer: is deprecated
+//     - Methods added:
+//         - deleteFileNamed:fromServer:
+//         - chmodFileNamed:to:atServer:
+//         - checkLogin:
+//     - cleaned up the code a little
+//
+// ** 1.6 (2013-01-13) by nkreipke
+//     - FMServer:
+//         - fixed a bug where variables were not retained properly
+//         - FMServer.destination is now NSString! You will have to change that in your code.
+//         - In FMSever.port the port can be specified. This is 21 by default.
+//     - fixed a bug where an empty file was created if downloadFile was not successful
+//
+// ** (1.6.1 -> release for CocoaPods)
+//
+// ** 1.6.2 (2013-04-24) by nkreipke
+//     - fixed a bug that occured in iOS 6 (https://github.com/nkreipke/FTPManager/issues/5)
+//     - fixed garbage value bug
+//
+// ** 1.6.3 (2014-01-25) by nkreipke
+//     - fixed a memory leak
+//
+// ** 1.6.4 (2014-06-13) by nkreipke
+//     - fixed crash that can occur when scheduling the stream (thanks to Kevin Paunovic)
+//     - fixed race condition bug while aborting
+//     - a separate NSThread is now used instead of using whatever thread FTPManager was called on
+//     - fixed bug that prevented subdirectories from being accessed when port was not 21
+//     - fixed bug that prevented subdirectories with names containing spaces from being accessed
+//
+// ** 1.6.5 (2014-08-12) by nkreipke
+//     - kCFFTPResourceName entry is now converted into UTF8 encoding to cope with Non-ASCII characters
+//
+
+#import "NKFTPManager.h"
+
+#import "VMMLogUtility.h"
+
+#define And(val1, val2) { val1 = val1 && val2; }
+#define AndV(val1, val2, message) { And(val1, val2); if (!val2) NSDebugLog(message); }
+#define Check(val1) { if (val1 == NO) return NO; }
+
+#pragma mark -
+
+#define RunInSeparateThread(...) \
+({__block __typeof__(__VA_ARGS__) result; \
+[FMThread runInSeparateThread:^{ result = (__VA_ARGS__); }]; \
+result;})
+
+@interface FMThread : NSObject {
+@private
+    NSCondition *waitCondition;
+}
+@property (copy) void (^block)(void);
++ (void)runInSeparateThread:(void (^)(void))block;
+@end
+
+@implementation FMThread
+
++ (void)runInSeparateThread:(void (^)(void))block {
+    FMThread *thread = [[FMThread alloc] init];
+    thread.block = block;
+    thread->waitCondition = [[NSCondition alloc] init];
+    
+    [thread->waitCondition lock];
+    
+    NSThread *t = [[NSThread alloc] initWithTarget:thread selector:@selector(threadMain) object:nil];
+    [t start];
+    [thread->waitCondition wait];
+    [thread->waitCondition unlock];
+}
+- (void)threadMain {
+    @autoreleasepool {
+        self.block();
+        
+        [waitCondition broadcast];
+    }
+}
+
+@end
+
+@interface NKFTPManager ()
+
+@property (nonatomic, readonly) uint8_t *         buffer;
+@property (nonatomic, assign)   size_t            bufferOffset;
+@property (nonatomic, assign)   size_t            bufferLimit;
+
+- (void) _streamDidEndWithSuccess:(BOOL)success failureReason:(FMStreamFailureReason)failureReason;
+- (BOOL) _ftpActionForServer:(FMServer*)server command:(NSString*)fullCommand;
+@end
+
+@implementation NKFTPManager
+
+@synthesize bufferOffset    = _bufferOffset;
+@synthesize bufferLimit     = _bufferLimit;
+@synthesize delegate        = _delegate;
+
+#pragma mark - Internal
+
+- (uint8_t *)buffer {
+    return self->_buffer;
+}
+- (id)init {
+    self = [super init];
+    if (self) {
+        // Initialization code here.
+    }
+    
+    return self;
+}
+
+- (BOOL) _checkFMServer:(FMServer*)server {
+    BOOL success = YES;
+    AndV(success, (server != nil), @"FMServer check failed: server cannot be nil");
+    Check(success);
+    AndV(success, (server.destination != nil), @"FMServer check failed: destination cannot be nil");
+    AndV(success, (server.username != nil), @"FMServer check failed: username cannot be nil");
+    AndV(success, (server.password != nil), @"FMServer check failed: password cannot be nil");
+    AndV(success, (server.port > 0), @"FMServer check failed: port cannot be negative");
+    return success;
+}
+
+- (unsigned long long) fileSizeOf:(NSURL*)file {
+    NSDictionary* attrib = [[NSFileManager defaultManager] attributesOfItemAtPath:file.path error:nil];
+    if (!attrib) {
+        return 0;
+    }
+    return [attrib fileSize];
+}
+
+- (NSArray*) _createListingArrayFromDirectoryListingData:(NSMutableData*)data {
+    NSMutableArray* listingArray = [NSMutableArray array];
+    
+    NSUInteger offset = 0;
+    do {
+        CFIndex bytesConsumed;
+        CFDictionaryRef thisEntry = NULL;
+        bytesConsumed = CFFTPCreateParsedResourceListing(NULL, &((const uint8_t *) self.directoryListingData.bytes)[offset],
+                                                         self.directoryListingData.length - offset, &thisEntry);
+        if (bytesConsumed > 0) {
+            if (thisEntry != NULL) {
+                NSMutableDictionary *entry = [NSMutableDictionary dictionaryWithDictionary:(__bridge NSDictionary *)thisEntry];
+                
+                // Converting kCFFTPResourceName entry to UTF8 to fix errors with Non-ASCII chars
+                NSString *nameEntry;
+                if ((nameEntry = entry[(id)kCFFTPResourceName])) {
+                    entry[(id)kCFFTPResourceName] = [[NSString alloc] initWithData:[nameEntry dataUsingEncoding:NSMacOSRomanStringEncoding allowLossyConversion:YES]
+                                                                          encoding:NSUTF8StringEncoding];
+                }
+                
+                [listingArray addObject:entry];
+            }
+            offset += bytesConsumed;
+        }
+        
+        if (thisEntry != NULL) {
+            CFRelease(thisEntry);
+        }
+        
+        if (bytesConsumed == 0) {
+            break;
+        } else if (bytesConsumed < 0) {
+            return nil;
+        }
+    } while (YES);
+    
+    return listingArray;
+}
+
+- (BOOL) _uploadData:(NSData *)data withFileName:(NSString *)fileName toServer:(FMServer *)server {
+    BOOL success = YES;
+    
+    action = _FMCurrentActionUploadFile;
+    
+    fileSize = data.length;
+    fileSizeProcessed = 0;
+    
+    NSURL * finalURL = [[server.destination ftpURLForPort:server.port] URLByAppendingPathComponent:fileName];
+    And(success, (finalURL != nil));
+    Check(success);
+    
+    self.fileReader = [[NSInputStream alloc] initWithData:data];
+    And(success, (self.fileReader != nil));
+    Check(success);
+    [self.fileReader open];
+    
+    CFWriteStreamRef writeStream = CFWriteStreamCreateWithFTPURL(NULL, (__bridge CFURLRef)finalURL);
+    And(success, (writeStream != NULL));
+    Check(success);
+    self.serverStream = (__bridge_transfer NSOutputStream*) writeStream;
+    
+    And(success, [self.serverStream setProperty:server.username forKey:(id)kCFStreamPropertyFTPUserName]);
+    And(success, [self.serverStream setProperty:server.password forKey:(id)kCFStreamPropertyFTPPassword]);
+    Check(success);
+    
+    self.bufferOffset = 0;
+    self.bufferLimit = 0;
+    
+    currentRunLoop = CFRunLoopGetCurrent();
+    
+    self.serverStream.delegate = self;
+    [self.serverStream open];
+    [self.serverStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    
+    CFRunLoopRun();
+    
+    And(success, streamSuccess);
+    
+    return success;
+}
+
+- (BOOL) _uploadFile:(NSURL*)fileURL toServer:(FMServer*)server {
+    BOOL success = YES;
+    
+    action = _FMCurrentActionUploadFile;
+    
+    fileSize = [self fileSizeOf:fileURL];
+    fileSizeProcessed = 0;
+    
+    NSString* fileName = [fileURL lastPathComponent];
+    NSURL * finalURL = [[server.destination ftpURLForPort:server.port] URLByAppendingPathComponent:fileName];
+    And(success, (finalURL != nil));
+    Check(success);
+    
+    self.fileReader = [[NSInputStream alloc] initWithFileAtPath:fileURL.path];
+    And(success, (self.fileReader != nil));
+    Check(success);
+    [self.fileReader open];
+    
+    CFWriteStreamRef writeStream = CFWriteStreamCreateWithFTPURL(NULL, (__bridge CFURLRef)finalURL);
+    And(success, (writeStream != NULL));
+    Check(success);
+    self.serverStream = (__bridge_transfer NSOutputStream*) writeStream;
+    
+    And(success, [self.serverStream setProperty:server.username forKey:(id)kCFStreamPropertyFTPUserName]);
+    And(success, [self.serverStream setProperty:server.password forKey:(id)kCFStreamPropertyFTPPassword]);
+    Check(success);
+    
+    self.bufferOffset = 0;
+    self.bufferLimit = 0;
+    
+    currentRunLoop = CFRunLoopGetCurrent();
+    
+    self.serverStream.delegate = self;
+    [self.serverStream open];
+    [self.serverStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    
+    CFRunLoopRun();
+    
+    And(success, streamSuccess);
+    
+    return success;
+}
+- (BOOL) _createNewFolder:(NSString*)folderName atServer:(FMServer*)server {
+    BOOL success = YES;
+    
+    action = _FMCurrentActionCreateNewFolder;
+    
+    fileSize = 0;
+    
+    NSURL * finalURL = [[server.destination ftpURLForPort:server.port] URLByAppendingPathComponent:folderName isDirectory:YES];
+    And(success, (finalURL != nil));
+    Check(success);
+    
+    CFWriteStreamRef writeStream = CFWriteStreamCreateWithFTPURL(NULL, (__bridge CFURLRef)finalURL);
+    And(success, (writeStream != NULL));
+    Check(success);
+    self.serverStream = (__bridge_transfer NSOutputStream*) writeStream;
+    
+    And(success, [self.serverStream setProperty:server.username forKey:(id)kCFStreamPropertyFTPUserName]);
+    And(success, [self.serverStream setProperty:server.password forKey:(id)kCFStreamPropertyFTPPassword]);
+    Check(success);
+    
+    self.bufferOffset = 0;
+    self.bufferLimit = 0;
+    
+    currentRunLoop = CFRunLoopGetCurrent();
+    
+    self.serverStream.delegate = self;
+    [self.serverStream open];
+    [self.serverStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    
+    CFRunLoopRun();
+    
+    And(success, streamSuccess);
+    
+    return success;
+}
+
+- (NSArray*) _contentsOfServer:(FMServer*)server {
+    BOOL success = YES;
+    
+    action = _FMCurrentActionContentsOfServer;
+    
+    fileSize = 0;
+    
+    self.directoryListingData = [[NSMutableData alloc] init];
+    
+    NSURL* dest = [server.destination ftpURLForPort:server.port];
+    And(success, (dest != nil));
+    if (!success) return nil;
+    
+    if (![dest.absoluteString hasSuffix:@"/"]) {
+        //if the url does not end with an '/' the method fails.
+        //no problem, we can fix this.
+        dest = [NSURL URLWithString:[NSString stringWithFormat:@"%@/",dest.absoluteString]];
+    }
+    
+    CFReadStreamRef readStream = CFReadStreamCreateWithFTPURL(NULL, (__bridge CFURLRef)dest);
+    And(success, (readStream != NULL));
+    if (!success) return nil;
+    self.serverReadStream = (__bridge_transfer NSInputStream*) readStream;
+    
+    And(success, [self.serverReadStream setProperty:server.username forKey:(id)kCFStreamPropertyFTPUserName]);
+    And(success, [self.serverReadStream setProperty:server.password forKey:(id)kCFStreamPropertyFTPPassword]);
+    if (!success) return nil;
+    
+    self.bufferOffset = 0;
+    self.bufferLimit = 0;
+    
+    currentRunLoop = CFRunLoopGetCurrent();
+    
+    self.serverReadStream.delegate = self;
+    [self.serverReadStream open];
+    [self.serverReadStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    
+    CFRunLoopRun();
+    
+    And(success, streamSuccess);
+    if (!success) return nil;
+    
+    NSArray* directoryContents = [self _createListingArrayFromDirectoryListingData:self.directoryListingData];
+    self.directoryListingData = nil;
+    
+    return directoryContents;
+}
+- (BOOL) _downloadFile:(NSString*)fileName toDirectory:(NSURL*)directoryURL fromServer:(FMServer*)server {
+    BOOL success = YES;
+    
+    action = _FMCurrentActionDownloadFile;
+    
+    fileSize = 0;
+    fileSizeProcessed = 0;
+    
+    NSString* filePath = [directoryURL URLByAppendingPathComponent:fileName].path;
+    
+    self.fileWriter = [[NSOutputStream alloc] initToFileAtPath:filePath append:NO];
+    And(success, (self.fileWriter != nil));
+    Check(success);
+    [self.fileWriter open];
+    
+    CFReadStreamRef readStream = CFReadStreamCreateWithFTPURL(NULL, (__bridge CFURLRef)[[server.destination ftpURLForPort:server.port] URLByAppendingPathComponent:fileName]);
+    And(success, (readStream != NULL));
+    Check(success);
+    self.serverReadStream = (__bridge_transfer NSInputStream*) readStream;
+    
+    And(success, [self.serverReadStream setProperty:server.username forKey:(id)kCFStreamPropertyFTPUserName]);
+    And(success, [self.serverReadStream setProperty:server.password forKey:(id)kCFStreamPropertyFTPPassword]);
+    And(success, [self.serverReadStream setProperty:[NSNumber numberWithBool:YES] forKey:(id)kCFStreamPropertyFTPFetchResourceInfo]);
+    Check(success);
+    
+    self.bufferOffset = 0;
+    self.bufferLimit = 0;
+    
+    currentRunLoop = CFRunLoopGetCurrent();
+    
+    self.serverReadStream.delegate = self;
+    [self.serverReadStream open];
+    [self.serverReadStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    
+    CFRunLoopRun();
+    
+    And(success, streamSuccess);
+    
+    if (!success && [[NSFileManager defaultManager] fileExistsAtPath:filePath]) {
+        //if the download fails, we try to delete the empty file created by the stream.
+        [[NSFileManager defaultManager] removeItemAtPath:filePath error:nil];
+    }
+    
+    return success;
+}
+
+#pragma mark - Public Methods
+
+- (BOOL) uploadData:(NSData*)data withFileName:(NSString *)fileName toServer:(FMServer*)server {
+    if (![self _checkFMServer:server]) {
+        return NO;
+    }
+    if (!data) {
+        return NO;
+    }
+    return RunInSeparateThread([self _uploadData:data withFileName:fileName toServer:server]);
+}
+- (BOOL) uploadFile:(NSURL*)fileURL toServer:(FMServer*)server {
+    if (![self _checkFMServer:server]) {
+        return NO;
+    }
+    if (!fileURL) {
+        return NO;
+    }
+    BOOL isDir;
+    if (![[NSFileManager defaultManager] fileExistsAtPath:fileURL.path isDirectory:&isDir] || isDir) {
+        return NO;
+    }
+    return RunInSeparateThread([self _uploadFile:fileURL toServer:server]);
+}
+- (BOOL) createNewFolder:(NSString*)folderName atServer:(FMServer*)server {
+    if (![self _checkFMServer:server]) {
+        return NO;
+    }
+    if (!folderName) {
+        return NO;
+    }
+    if ([folderName isEqualToString:@""]) {
+        return NO;
+    }
+    return RunInSeparateThread([self _createNewFolder:folderName atServer:server]);
+}
+- (BOOL) deleteFileNamed:(NSString*)fileName fromServer:(FMServer*)server {
+    if (![self _checkFMServer:server]) {
+        return NO;
+    }
+    if (!fileName) {
+        return NO;
+    }
+    NSString* cmd;
+    if ([fileName rangeOfString:@"."].location != NSNotFound) {
+        //probably a file
+        cmd = @"DELE";
+    } else {
+        //probably a directory (this will only succeed if the dir is empty)
+        cmd = @"RMD";
+    }
+    return RunInSeparateThread([self _ftpActionForServer:server command:[NSString stringWithFormat:@"%@ %@",cmd,fileName]]);
+}
+- (BOOL) deleteFile:(NSString *)absolutePath fromServer:(FMServer *)server {
+    //this is deprecated.
+    //the method may not behave like it used to.
+    return RunInSeparateThread([self deleteFileNamed:absolutePath fromServer:server]);
+}
+
+- (BOOL) chmodFileNamed:(NSString*)fileName to:(int)mode atServer:(FMServer*)server {
+    if (![self _checkFMServer:server]) {
+        return NO;
+    }
+    if (!fileName) {
+        return NO;
+    }
+    if (mode < 0 || mode > 777) {
+        return NO;
+    }
+    return RunInSeparateThread([self _ftpActionForServer:server command:[NSString stringWithFormat:@"SITE CHMOD %i %@",mode,fileName]]);
+}
+- (NSArray*) contentsOfServer:(FMServer*)server {
+    if (![self _checkFMServer:server]) {
+        return nil;
+    }
+    return RunInSeparateThread([self _contentsOfServer:server]);
+}
+- (BOOL) downloadFile:(NSString*)fileName toDirectory:(NSURL*)directoryURL fromServer:(FMServer*)server {
+    if (![self _checkFMServer:server]) {
+        return NO;
+    }
+    if (!fileName) {
+        return NO;
+    }
+    if ([fileName isEqualToString:@""]) {
+        return NO;
+    }
+    if (!directoryURL) {
+        return NO;
+    }
+    if (![[NSFileManager defaultManager] fileExistsAtPath:directoryURL.path]) {
+        return NO;
+    }
+    return RunInSeparateThread([self _downloadFile:fileName toDirectory:directoryURL fromServer:server]);
+}
+- (BOOL) checkLogin:(FMServer*)server {
+    if (![self _checkFMServer:server]) {
+        return NO;
+    }
+    return RunInSeparateThread([self _ftpActionForServer:server command:nil]);
+}
+- (NSMutableDictionary *) progress {
+    //this does only work with uploadFile and downloadFile.
+    NSStream* currentStream;
+    switch (action) {
+        case _FMCurrentActionUploadFile:
+            currentStream = self.serverStream;
+            break;
+        case _FMCurrentActionDownloadFile:
+            currentStream = self.serverReadStream;
+            break;
+        default:
+            break;
+    }
+    
+    if (!currentStream || fileSize == 0) {
+        return nil;
+    }
+    
+    NSMutableDictionary *returnValues = [[NSMutableDictionary alloc] init];
+    
+    [returnValues setValue:[NSNumber numberWithUnsignedLongLong:fileSize] forKey:kFMProcessInfoFileSize];
+    [returnValues setValue:[NSNumber numberWithUnsignedLongLong:bytesProcessed] forKey:kFMProcessInfoBytesProcessed];
+    [returnValues setValue:[NSNumber numberWithUnsignedLongLong:fileSizeProcessed] forKey:kFMProcessInfoFileSizeProcessed];
+    [returnValues setValue:[NSNumber numberWithFloat:(float)fileSizeProcessed / (float)fileSize] forKey:kFMProcessInfoProgress];
+    
+    return returnValues;
+}
+
+- (void)abort {
+    NSStream* currentStream;
+    switch (action) {
+        case _FMCurrentActionUploadFile:
+            currentStream = self.serverStream;
+            break;
+        case _FMCurrentActionDownloadFile:
+            currentStream = self.serverReadStream;
+            break;
+        case _FMCurrentActionCreateNewFolder:
+            currentStream = self.serverStream;
+            break;
+        case _FMCurrentActionContentsOfServer:
+            currentStream = self.serverReadStream;
+            break;
+        default:
+            break;
+    }
+    if (!currentStream) {
+        return;
+    }
+    
+    [self _streamDidEndWithSuccess:YES failureReason:FMStreamFailureReasonAborted];
+    
+    [currentStream close];
+}
+
+#pragma mark - Stream
+
+-(void) _streamDidEndWithSuccess:(BOOL)success failureReason:(FMStreamFailureReason)failureReason {
+    if (!currentRunLoop)
+        return;
+    
+    CFRunLoopRef runloop = currentRunLoop;
+    currentRunLoop = NULL;
+    
+    action = _FMCurrentActionNone;
+    streamSuccess = success;
+    if (!streamSuccess) {
+        switch (failureReason) {
+            case FMStreamFailureReasonReadError:
+                NSDebugLog(@"ftp stream failed: error while reading data");
+                break;
+            case FMStreamFailureReasonWriteError:
+                NSDebugLog(@"ftp stream failed: error while writing data");
+                break;
+            case FMStreamFailureReasonGeneralError:
+                NSDebugLog(@"ftp stream failed: general stream error (check credentials?)");
+                break;
+            default:
+                break;
+        }
+    }
+    if (self.serverStream) {
+        [self.serverStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+        self.serverStream.delegate = nil;
+        [self.serverStream close];
+        self.serverStream = nil;
+    }
+    if (self.serverReadStream) {
+        [self.serverReadStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+        self.serverReadStream.delegate = nil;
+        [self.serverReadStream close];
+        self.serverReadStream = nil;
+    }
+    if (self.fileReader) {
+        [self.fileReader close];
+        self.fileReader = nil;
+    }
+    if (self.fileWriter) {
+        [self.fileWriter close];
+        self.fileWriter = nil;
+    }
+    
+    CFRunLoopStop(runloop);
+}
+-(void)stream:(NSStream *)theStream handleEvent:(NSStreamEvent)streamEvent {
+    switch (streamEvent) {
+        case NSStreamEventOpenCompleted:
+            if (action == _FMCurrentActionDownloadFile) {
+                fileSize = [[theStream propertyForKey:(id)kCFStreamPropertyFTPResourceSize] longLongValue];
+                
+                if (self.delegate && [self.delegate respondsToSelector:@selector(ftpManagerDownloadProgressDidChange:)]) {
+                    [self.delegate ftpManagerDownloadProgressDidChange:[self progress]];
+                }
+            }
+            break;
+        case NSStreamEventHasBytesAvailable:
+            if (action == _FMCurrentActionContentsOfServer) {
+                NSInteger       bytesRead;
+                
+                bytesRead = [self.serverReadStream read:self.buffer maxLength:kSendBufferSize];
+                if (bytesRead == -1) {
+                    [self _streamDidEndWithSuccess:NO failureReason:FMStreamFailureReasonReadError];
+                } else if (bytesRead == 0) {
+                    [self _streamDidEndWithSuccess:YES failureReason:FMStreamFailureReasonNone];
+                } else {
+                    [self.directoryListingData appendBytes:self.buffer length:bytesRead];
+                }
+            } else if (action == _FMCurrentActionDownloadFile) {
+                if (self.bufferOffset == self.bufferLimit) {
+                    //fill buffer with data from server
+                    NSInteger   bytesRead;
+                    
+                    bytesRead = [self.serverReadStream read:self.buffer maxLength:kSendBufferSize];
+                    
+                    if (bytesRead == -1) {
+                        [self _streamDidEndWithSuccess:NO failureReason:FMStreamFailureReasonReadError];
+                    } else if (bytesRead == 0) {
+                        [self _streamDidEndWithSuccess:YES failureReason:FMStreamFailureReasonNone];
+                    } else {
+                        self.bufferOffset = 0;
+                        self.bufferLimit  = bytesRead;
+                        fileSizeProcessed += bytesRead;
+                        bytesProcessed = bytesRead;
+                        
+                        if (self.delegate && [self.delegate respondsToSelector:@selector(ftpManagerDownloadProgressDidChange:)]) {
+                            [self.delegate ftpManagerDownloadProgressDidChange:[self progress]];
+                        }
+                    }
+                }
+                if (self.bufferOffset != self.bufferLimit) {
+                    //fill file with buffer
+                    NSInteger   bytesWritten;
+                    bytesWritten = [self.fileWriter write:&self.buffer[self.bufferOffset] maxLength:self.bufferLimit - self.bufferOffset];
+                    if (bytesWritten == -1 || bytesWritten == 0) {
+                        [self _streamDidEndWithSuccess:NO failureReason:FMStreamFailureReasonWriteError];
+                    } else {
+                        self.bufferOffset += bytesWritten;
+                    }
+                }
+            } else {
+                //something went wrong here...
+                [self _streamDidEndWithSuccess:NO failureReason:FMStreamFailureReasonGeneralError];
+            }
+            break;
+        case NSStreamEventHasSpaceAvailable:
+            if (action == _FMCurrentActionUploadFile) {
+                if (self.bufferOffset == self.bufferLimit) {
+                    //read process
+                    //fill buffer with data
+                    NSInteger   bytesRead;
+                    
+                    bytesRead = [self.fileReader read:self.buffer maxLength:kSendBufferSize];
+                    
+                    if (bytesRead == -1) {
+                        [self _streamDidEndWithSuccess:NO failureReason:FMStreamFailureReasonReadError];
+                    } else if (bytesRead == 0) {
+                        [self _streamDidEndWithSuccess:YES failureReason:FMStreamFailureReasonNone];
+                    } else {
+                        self.bufferOffset = 0;
+                        self.bufferLimit  = bytesRead;
+                    }
+                }
+                
+                if (self.bufferOffset != self.bufferLimit) {
+                    //write process
+                    //write data out of buffer to server
+                    NSInteger   bytesWritten;
+                    bytesWritten = [self.serverStream write:&self.buffer[self.bufferOffset] maxLength:self.bufferLimit - self.bufferOffset];
+                    if (bytesWritten == -1 || bytesWritten == 0) {
+                        [self _streamDidEndWithSuccess:NO failureReason:FMStreamFailureReasonWriteError];
+                    } else {
+                        self.bufferOffset += bytesWritten;
+                        fileSizeProcessed += bytesWritten;
+                        bytesProcessed = bytesWritten;
+                        
+                        if (self.delegate && [self.delegate respondsToSelector:@selector(ftpManagerUploadProgressDidChange:)]) {
+                            [self.delegate ftpManagerUploadProgressDidChange:[self progress]];
+                        }
+                    }
+                }
+            } else {
+                //something went wrong here...
+                [self _streamDidEndWithSuccess:NO failureReason:FMStreamFailureReasonGeneralError];
+            }
+            break;
+        case NSStreamEventErrorOccurred:
+            [self _streamDidEndWithSuccess:NO failureReason:FMStreamFailureReasonGeneralError];
+            break;
+        case NSStreamEventEndEncountered:
+            if (action == _FMCurrentActionCreateNewFolder) {
+                [self _streamDidEndWithSuccess:YES failureReason:FMStreamFailureReasonNone];
+            }
+            break;
+        default:
+            break;
+    }
+}
+
+#pragma mark - Sockets
+
+//These are some functions written in C. They use sockets to communicate with a FTP server.
+//We use this for deletion and chmod.
+
+-(NSString*) _listenLoopForSocket:(int)sockfd {
+    NSString* answer = @"";
+    char buffer[256];
+    ssize_t n = 1;
+    while (n > 0) {
+        bzero(buffer, 256);
+        n = read(sockfd, buffer, 255);
+        if (n < 0) {
+            NSDebugLog(@"Error reading from socket!");
+        } else {
+            NSString* b = [NSString stringWithCString:buffer encoding:NSUTF8StringEncoding];
+            answer = [NSString stringWithFormat:@"%@\n%@",answer,b];
+#ifdef FMSOCKET_VERBOSE
+            NSDebugLog(@"%s",buffer);
+#endif
+        }
+    }
+    return answer;
+}
+-(BOOL) _checkAnswers:(NSString*)a {
+    NSArray* answers = [a componentsSeparatedByString:@"\n"];
+    //we are interested in the first character of the answer.
+    //if this is a 4 or 5, the corresponding command failed.
+    for (NSString* answer in answers) {
+        const char*canswer = [answer cStringUsingEncoding:NSUTF8StringEncoding];
+        char first = *canswer;
+        if (first == '4' || first == '5') {
+            return NO;
+        }
+    }
+    return YES;
+}
+-(BOOL) _ftpActionForServer:(FMServer*)server command:(NSString*)fullCommand {
+    //At first, we send all the commands, then we fetch the answers
+    //to find out whether we were successful.
+    
+    action = _FMCurrentActionSOCKET;
+    
+    const char *host = [[server.destination fmhost] cStringUsingEncoding:NSUTF8StringEncoding];
+    const char *user = [server.username cStringUsingEncoding:NSUTF8StringEncoding];
+    const char *pass = [server.password cStringUsingEncoding:NSUTF8StringEncoding];
+    NSString* wdirs = [server.destination fmdir];
+    const char *wdir;
+    BOOL chdir = NO;
+    if (wdirs && wdirs.length > 0) {
+        wdir = [wdirs cStringUsingEncoding:NSUTF8StringEncoding];
+        chdir = YES;
+    }
+    char cmd[256];
+    ssize_t n;
+    struct sockaddr_in serv_addr;
+    struct hostent *srv;
+    int sockfd = socket(AF_INET, SOCK_STREAM, 0);
+    if (sockfd < 0) {
+        NSDebugLog(@"could not open socket!");
+        return NO;
+    }
+    srv = gethostbyname(host);
+    if (srv == NULL) {
+        NSDebugLog(@"host error!");
+        return NO;
+    }
+    bzero((char*)&serv_addr, sizeof(serv_addr));
+    serv_addr.sin_family = AF_INET;
+    bcopy((char*)srv->h_addr,
+          (char*)&serv_addr.sin_addr.s_addr,
+          srv->h_length);
+    serv_addr.sin_port = htons(server.port);
+    if (connect(sockfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr)) < 0) {
+        NSDebugLog(@"error connecting.");
+        return NO;
+    }
+    //it is very easy to connect to the control connection of an ftp server,
+    //as it is based on the Telnet protocol.
+    
+    //at this point, there is a connection.
+    //we now send login commands
+    sprintf(cmd, "USER %s\r\n", user);
+    n = write(sockfd, cmd, strlen(cmd));
+    if (n < 0) return NO;
+    bzero(cmd, 256);
+    sprintf(cmd, "PASS %s\r\n", pass);
+    n = write(sockfd, cmd, strlen(cmd));
+    if (n < 0) return NO;
+    //logged in!
+    if (fullCommand) {
+        if (chdir) {
+            //switch into the working directory:
+            bzero(cmd, 256);
+            sprintf(cmd, "CWD %s\r\n", wdir);
+            n = write(sockfd, cmd, strlen(cmd));
+            if (n < 0) return NO;
+        }
+#ifdef FMSOCKET_VERBOSE
+        //if verbose, print out location:
+        bzero(cmd, 256);
+        sprintf(cmd, "PWD\r\n");
+        n = write(sockfd, cmd, strlen(cmd));
+        if (n < 0) return NO;
+#endif
+        //now send the command:
+        bzero(cmd, 256);
+        sprintf(cmd, "%s\r\n", [fullCommand cStringUsingEncoding:NSUTF8StringEncoding]);
+        n = write(sockfd, cmd, strlen(cmd));
+        if (n < 0) return NO;
+    }
+    //and say goodbye:
+    bzero(cmd, 256);
+    sprintf(cmd, "QUIT\r\n");
+    n = write(sockfd, cmd, strlen(cmd));
+    if (n < 0) return NO;
+    // --------
+    //now, fetch the answers:
+    NSString* answer = [self _listenLoopForSocket:sockfd];
+    close(sockfd);
+    
+    streamSuccess = [self _checkAnswers:answer];
+    action = _FMCurrentActionNone;
+    
+    return streamSuccess;
+}
+
+@end
+
+#pragma mark -
+
+@implementation FMServer
+@synthesize password, username, destination, port;
+-(id)init {
+    self = [super init];
+    if (self) {
+        self.port = 21;
+    }
+    return self;
+}
++(FMServer*)serverWithDestination:(NSString*)dest username:(NSString*)user password:(NSString*)pass {
+    FMServer* server = [[FMServer alloc] init];
+    server.destination = dest;
+    server.username = user;
+    server.password = pass;
+    return server;
+}
++(FMServer*)anonymousServerWithDestination:(NSString*)dest {
+    FMServer* server = [[FMServer alloc] init];
+    server.destination = dest;
+    server.username = FTPANONYMOUS;
+    server.password = @"";
+    return server;
+}
+@end
+
+@implementation NSString (FTPManagerNSStringAdditions)
+-(NSString*)stringWithoutProtocol {
+    NSString* urlString = [NSString stringWithString:self];
+    NSRange range = [urlString rangeOfString:@"://"];
+    if (range.location != NSNotFound) {
+        urlString = [urlString substringFromIndex:range.location + 3];
+    }
+    //test whether a port is included (which would not work)
+    NSRange rangeP = [urlString rangeOfString:@":"];
+    if (rangeP.location != NSNotFound) {
+        const char *ptr = [urlString cStringUsingEncoding:NSUTF8StringEncoding];
+        while (*ptr != '/' && *ptr != '\0') {
+            if (*(ptr++) == ':') {
+                NSDebugLog(@"FTPManager warning: there is possibly a port included in your destination url. Define the port in FMServer.port instead.");
+                break;
+            }
+        }
+    }
+    return urlString;
+}
+-(NSURL*)ftpURLForPort:(int)port {
+    //returns the complete url including the directory
+    // -> ftp://test.com/test/test
+    NSString *host = port == 21 ? self.fmhost : [NSString stringWithFormat:@"%@:%i", self.fmhost, port];
+    NSString *hostWithProtocol = [NSString stringWithFormat:@"ftp://%@", host];
+    
+    NSURL *url = [NSURL URLWithString:hostWithProtocol];
+    NSString *fmdir = self.fmdir;
+    if (fmdir && fmdir.length > 0)
+        url = [url URLByAppendingPathComponent:fmdir];
+    
+    return url;
+}
+-(NSString*)fmhost {
+    //returns the host
+    // ftp://test.com/test/test -> test.com
+    NSString* u = [self stringWithoutProtocol];
+    NSRange fs = [u rangeOfString:@"/"];
+    if (fs.location != NSNotFound) {
+        return [u substringToIndex:fs.location];
+    } else {
+        return u;
+    }
+}
+-(NSString*)fmdir {
+    //returns the working directory
+    // ftp://test.com/test/test -> test/test
+    NSString* u = [self stringWithoutProtocol];
+    
+    NSRange fs = [u rangeOfString:@"/"];
+    if (fs.location == NSNotFound) {
+        return nil;
+    } else {
+        return [u substringFromIndex:fs.location+1];
+    }
+}
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSApplication+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSApplication+Extension.h
@@ -1,0 +1,35 @@
+//
+//  NSApplication+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 23/12/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#ifndef NSApplication_Extension_Class
+#define NSApplication_Extension_Class
+
+#import <Cocoa/Cocoa.h>
+#import "VMMComputerInformation.h"
+
+#define VMMAppearanceDarkPreMojaveCompatible IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define VMMAppearanceDarkCompatible          IS_SYSTEM_MAC_OS_10_14_OR_SUPERIOR
+
+typedef NSString* VMMAppearanceName;
+
+static VMMAppearanceName _Nonnull const VMMAppearanceNameLight         = @"NSAppearanceNameAqua";
+static VMMAppearanceName _Nonnull const VMMAppearanceNameDarkPreMojave = @"NSAppearanceNameVibrantDark";
+static VMMAppearanceName _Nonnull const VMMAppearanceNameDark          = @"NSAppearanceNameDarkAqua";
+
+@interface NSApplication (VMMApplication)
+
++(void)restart;
++(void)restartInLanguage:(nonnull NSString*)language;
+
++(nullable VMMAppearanceName)appearance;
++(BOOL)setAppearance:(nullable VMMAppearanceName)appearance;
+
+@end
+
+#endif
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSApplication+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSApplication+Extension.m
@@ -1,0 +1,87 @@
+//
+//  NSApplication+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 23/12/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import "NSApplication+Extension.h"
+
+#import "NSBundle+Extension.h"
+#import "NSTask+Extension.h"
+#import "NSException+Extension.h"
+#import "VMMLogUtility.h"
+#import "VMMComputerInformation.h"
+
+@implementation NSApplication (VMMApplication)
+
++(void)restart
+{
+    [NSTask runProgram:@"open" withFlags:@[@"-n", [[NSBundle originalMainBundle] bundlePath]]];
+    exit(0);
+}
+
++(void)restartInLanguage:(nonnull NSString*)language
+{
+    if ([VMMComputerInformation isSystemMacOsEqualOrSuperiorTo:@"10.6.2"] == false) {
+        // The '--args' parameter in 'open' was only introduced in macOS 10.6.2
+        // Reference: https://superuser.com/a/116237
+        
+        @throw exception(NSIllegalSelectorException, @"NSApplication does not implement restartInLanguage:");
+    }
+    
+    if ([[NSLocale availableLocaleIdentifiers] containsObject:language] == false) {
+        NSDebugLog(@"'%@' is not a valid locale identifier", language);
+        return;
+    }
+    
+    if ([[[NSBundle originalMainBundle] localizations] containsObject:language] == false) {
+        NSDebugLog(@"That application does not support '%@'", language);
+        return;
+    }
+    
+    if ([[[NSBundle originalMainBundle] preferredLocalizations] containsObject:language]) {
+        return;
+    }
+    
+    NSTask *task = [[NSTask alloc] init];
+    [task setLaunchPath:@"/bin/sh"];
+    NSString *cmd = [NSString stringWithFormat:@"/usr/bin/open %@ %@ %@ %@ %@",
+                     @"-n", @"-a", [[[NSBundle originalMainBundle] bundlePath] stringByReplacingOccurrencesOfString:@" " withString:@"\\ "],
+                     @"--args", [NSString stringWithFormat:@"-AppleLanguages '(%@)'",language]];
+    [task setArguments:[NSArray arrayWithObjects:@"-c", cmd, nil]];
+    [task launch];
+    
+    exit(0);
+}
+
++(nullable VMMAppearanceName)appearance
+{
+    if (VMMAppearanceDarkPreMojaveCompatible == false) {
+        return nil;
+    }
+    
+    NSAppearance* nsappearance = [NSApp appearance];
+    if (nsappearance == nil) {
+        return nil;
+    }
+    
+    return nsappearance.name;
+}
++(BOOL)setAppearance:(nullable VMMAppearanceName)appearance
+{
+    if (VMMAppearanceDarkPreMojaveCompatible == false) {
+        return false;
+    }
+    
+    @try {
+        NSAppearance* nsappearance = appearance != nil ? [NSAppearance appearanceNamed:appearance] : nil;
+        [NSApp setAppearance:nsappearance];
+        return true;
+    } @catch (NSException *exception) {
+        return false;
+    }
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSArray+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSArray+Extension.h
@@ -1,0 +1,29 @@
+//
+//  NSArray+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 15/05/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface NSArray<ObjectType> (VMMArray)
+
+-(nonnull NSMutableArray*)map:(_Nullable id (^_Nonnull)(id _Nonnull object))newObjectForObject;
+-(nonnull NSMutableArray*)mapWithIndex:(_Nullable id (^_Nonnull)(id _Nonnull object, NSUInteger index))newObjectForObject;
+-(nonnull NSMutableArray*)filter:(BOOL (^_Nonnull)(id _Nonnull object))newObjectForObject;
+-(nonnull NSMutableArray*)filterWithIndex:(BOOL (^_Nonnull)(id _Nonnull object, NSUInteger index))newObjectForObject;
+-(nonnull instancetype)forEach:(void (^_Nonnull)(id _Nonnull object))newObjectForObject;
+
+-(nonnull NSArray<ObjectType>*)arrayByRemovingRepetitions;
+-(nonnull NSArray<ObjectType>*)arrayByRemovingObjectsFromArray:(nonnull NSArray<ObjectType>*)otherArray;
+
+-(NSIndexSet* _Nonnull)indexesOfObject:(ObjectType _Nonnull)object inRange:(NSRange)range;
+-(NSIndexSet* _Nonnull)indexesOfObject:(ObjectType _Nonnull)object;
+
+-(NSInteger)lastIndexOfObject:(ObjectType _Nonnull)object inRange:(NSRange)range;
+
+-(void)differencesFromArray:(NSArray<ObjectType>* _Nonnull)otherArray indexPaths:(void (^_Nonnull)(NSArray<NSIndexSet*>* _Nonnull addedIndexes, NSArray<NSIndexSet*>* _Nonnull removedIndexes))indexPaths;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSArray+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSArray+Extension.m
@@ -1,0 +1,127 @@
+//
+//  NSArray+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 15/05/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSArray+Extension.h"
+
+#import "NSMutableArray+Extension.h"
+
+@implementation NSArray (VMMArray)
+
+-(nonnull NSMutableArray*)map:(_Nullable id (^_Nonnull)(id _Nonnull object))newObjectForObject
+{
+    return [[self mutableCopy] map:newObjectForObject];
+}
+-(nonnull NSMutableArray*)mapWithIndex:(_Nullable id (^_Nonnull)(id _Nonnull object, NSUInteger index))newObjectForObject
+{
+    return [[self mutableCopy] mapWithIndex:newObjectForObject];
+}
+-(nonnull NSMutableArray*)filter:(BOOL (^_Nonnull)(id _Nonnull object))newObjectForObject
+{
+    return [[self mutableCopy] filter:newObjectForObject];
+}
+-(nonnull NSMutableArray*)filterWithIndex:(BOOL (^_Nonnull)(id _Nonnull object, NSUInteger index))newObjectForObject
+{
+    return [[self mutableCopy] filterWithIndex:newObjectForObject];
+}
+-(nonnull instancetype)forEach:(void (^_Nonnull)(id _Nonnull object))newObjectForObject
+{
+    for (id object in self) {
+        newObjectForObject(object);
+    }
+    return self;
+}
+
+-(nonnull NSArray*)arrayByRemovingRepetitions
+{
+    return [NSSet setWithArray:self].allObjects;
+}
+
+-(nonnull NSArray*)arrayByRemovingObjectsFromArray:(nonnull NSArray*)otherArray
+{
+    NSMutableArray* newArray = [self mutableCopy];
+    
+    [newArray removeObjectsInArray:otherArray];
+    
+    return newArray;
+}
+
+-(NSIndexSet* _Nonnull)indexesOfObject:(id _Nonnull)object inRange:(NSRange)range
+{
+    return [self indexesOfObjectsPassingTest:^BOOL(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop)
+    {
+        if (idx < range.location)                 return false;
+        if (idx >= range.location + range.length) return false;
+        return obj == object || [obj isEqual:object];
+    }];
+}
+-(NSIndexSet* _Nonnull)indexesOfObject:(id _Nonnull)object
+{
+    return [self indexesOfObjectsPassingTest:^BOOL(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop)
+    {
+        return obj == object || [obj isEqual:object];
+    }];
+}
+
+-(NSInteger)lastIndexOfObject:(id _Nonnull)object inRange:(NSRange)range
+{
+    return (NSInteger)[self indexesOfObject:object inRange:range].lastIndex;
+}
+
+-(void)differencesFromArray:(NSArray* _Nonnull)otherArray indexPaths:(void (^_Nonnull)(NSArray<NSIndexSet*>* _Nonnull addedIndexes, NSArray<NSIndexSet*>* _Nonnull removedIndexes))indexPaths
+{
+    NSMutableArray* removedIndexPaths = [[NSMutableArray alloc] init];
+    NSMutableArray* addedIndexPaths   = [[NSMutableArray alloc] init];
+    NSInteger indexSelf  = self.count - 1;
+    NSInteger indexOther = otherArray.count - 1;
+    
+    while (indexSelf != -1 && indexOther != -1)
+    {
+        NSInteger nextSelfObjectInOther = [otherArray lastIndexOfObject:[self objectAtIndex:indexSelf]
+                                                                inRange:NSMakeRange(0, indexOther + 1)];
+        NSInteger nextOtherObjectInSelf = [self lastIndexOfObject:[otherArray objectAtIndex:indexOther]
+                                                          inRange:NSMakeRange(0, indexSelf + 1)];
+        
+        if (nextOtherObjectInSelf == NSNotFound)
+        {
+            [addedIndexPaths addObject:[NSIndexSet indexSetWithIndex:indexSelf+1]];
+            indexOther -= 1;
+            continue;
+        }
+        
+        if (nextSelfObjectInOther == NSNotFound)
+        {
+            [removedIndexPaths addObject:[NSIndexSet indexSetWithIndex:indexSelf]];
+            indexSelf -= 1;
+            continue;
+        }
+        
+        if (nextOtherObjectInSelf != -1 && nextOtherObjectInSelf == indexSelf)
+        {
+            indexSelf -=1;
+            indexOther -=1;
+            continue;
+        }
+    }
+    
+    while (indexSelf != -1)
+    {
+        [removedIndexPaths addObject:[NSIndexSet indexSetWithIndex:indexSelf]];
+        indexSelf -= 1;
+    }
+    
+    while (indexOther != -1)
+    {
+        [addedIndexPaths addObject:[NSIndexSet indexSetWithIndex:0]];
+        indexOther -= 1;
+    }
+    
+    indexPaths(addedIndexPaths, removedIndexPaths);
+}
+
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSAttributedString+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSAttributedString+Extension.h
@@ -1,0 +1,23 @@
+//
+//  NSAttributedString+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 12/03/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#ifndef NSAttributedString_Extension_Class
+#define NSAttributedString_Extension_Class
+
+#import <Cocoa/Cocoa.h>
+
+@interface NSAttributedString (VMMAttributedString)
+
+-(nullable instancetype)initWithHTMLData:(nonnull NSData*)data;
+-(nullable instancetype)initWithHTMLString:(nonnull NSString*)string;
+
+-(nonnull NSString*)htmlString;
+
+@end
+
+#endif

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSAttributedString+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSAttributedString+Extension.m
@@ -1,0 +1,43 @@
+//
+//  NSAttributedString+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 12/03/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSAttributedString+Extension.h"
+
+@implementation NSAttributedString (VMMAttributedString)
+
+-(nullable instancetype)initWithHTMLData:(nonnull NSData*)data
+{
+    self = [self initWithData:data options:@{NSDocumentTypeDocumentAttribute:     NSHTMLTextDocumentType,
+                                             NSCharacterEncodingDocumentAttribute:@(NSUTF8StringEncoding)}
+           documentAttributes:nil error:nil];
+    return self;
+}
+-(nullable instancetype)initWithHTMLString:(nonnull NSString*)string
+{
+    self = [self initWithHTMLData:[string dataUsingEncoding:NSUTF8StringEncoding]];
+    return self;
+}
+
+-(nonnull NSString*)htmlString
+{
+    NSString* htmlString;
+    
+    @autoreleasepool
+    {
+        NSDictionary *documentAttributes = @{NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType};
+        NSData *htmlData = [self dataFromRange:NSMakeRange(0, self.length) documentAttributes:documentAttributes error:NULL];
+        htmlString = [[NSString alloc] initWithData:htmlData encoding:NSUTF8StringEncoding];
+        
+        // That solves the double-line bug
+        htmlString = [htmlString stringByReplacingOccurrencesOfString:@"<br>" withString:@""];
+    }
+    
+    return htmlString;
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSBundle+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSBundle+Extension.h
@@ -1,0 +1,26 @@
+//
+//  NSBundle+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 25/11/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface NSBundle (VMMBundle)
+
+-(nonnull NSUserDefaults*)userDefaults;
+
+-(nonnull NSString*)bundleName;
+-(nullable NSImage*)bundleIcon;
+
+-(BOOL)isAppTranslocationActive;
+-(BOOL)disableAppTranslocation;
+
++(nullable NSBundle*)originalMainBundle;
+
+-(BOOL)preferExternalGPU;
+-(void)setPreferExternalGPU:(BOOL)prefer;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSBundle+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSBundle+Extension.m
@@ -1,0 +1,272 @@
+//
+//  NSBundle+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 25/11/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import "NSBundle+Extension.h"
+
+#import "NSTask+Extension.h"
+#import "NSException+Extension.h"
+#import "NSFileManager+Extension.h"
+#import "NSString+Extension.h"
+#import "NSUserDefaults+Extension.h"
+
+#import "VMMComputerInformation.h"
+
+#include <stdlib.h>
+#import <objc/runtime.h>
+
+static NSString* const BUNDLE_NAME_PLACEHOLDER = @"App";
+
+@implementation NSBundle (VMMBundle)
+
+NSBundle* _originalMainBundle;
+
+-(nonnull NSUserDefaults*)userDefaults
+{
+    NSUserDefaults *defaults = [[NSUserDefaults alloc] init];
+    [defaults addSuiteNamed:[self bundleIdentifier]];
+    return defaults;
+}
+
+-(nonnull NSString*)bundleName
+{
+    @synchronized(self)
+    {
+        NSString* bundleName = [self objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+        
+        if (bundleName == nil)
+        {
+            bundleName = [self objectForInfoDictionaryKey:@"CFBundleName"];
+        }
+        
+        if (bundleName == nil)
+        {
+            // Reference:
+            // https://stackoverflow.com/a/35322073/4370893
+            
+            bundleName = [NSString stringWithUTF8String:getprogname()];
+        }
+        
+        if (bundleName == nil)
+        {
+            NSString* newBundleName = self.bundlePath.stringByDeletingPathExtension.lastPathComponent;
+            if (newBundleName != nil) bundleName = newBundleName;
+        }
+        
+        if (bundleName != nil)
+        {
+            return bundleName;
+        }
+        
+        return BUNDLE_NAME_PLACEHOLDER;
+    }
+}
+-(nullable NSImage*)bundleIcon
+{
+    NSString* appImageFileName = [self objectForInfoDictionaryKey:@"CFBundleIconFile"];
+    
+    if (![appImageFileName hasSuffix:@".icns"])
+        appImageFileName = [appImageFileName stringByAppendingString:@".icns"];
+    
+    NSString* appImageCompletePath = [NSString stringWithFormat:@"%@/Contents/Resources/%@",[self bundlePath],appImageFileName];
+    
+    NSImage* appImage = [[NSImage alloc] initWithContentsOfFile:appImageCompletePath];
+    
+    return appImage;
+}
+
+-(BOOL)doesBundleAtPath:(NSString*)bundlePath executableMatchesWithMD5Checksum:(NSString*)checksum
+{
+    if ([[NSFileManager defaultManager] fileExistsAtPath:bundlePath] == false) return false;
+    
+    NSBundle* applicationInDesktopBundle = [[NSBundle alloc] initWithPath:bundlePath];
+    NSString* applicationInDesktopExecutablePath = [applicationInDesktopBundle executablePath];
+    if (!applicationInDesktopExecutablePath) return false;
+    
+    NSString* applicationInDesktopBinaryChecksum = [[NSFileManager defaultManager] checksum:NSChecksumTypeMD5
+                                                                               ofFileAtPath:applicationInDesktopExecutablePath];
+    return [applicationInDesktopBinaryChecksum isEqualToString:checksum];
+}
+-(NSString*)bundlePathBeforeAppTranslocation
+{
+    if (IS_SYSTEM_MAC_OS_10_15_OR_SUPERIOR) {
+        return nil;
+    }
+
+    @synchronized(self)
+    {
+        NSString* bundlePathBeforeAppTranslocation;
+        
+        @autoreleasepool
+        {    
+            NSString* appBinaryPath = [self executablePath];
+            NSString* appBundleFileName = [[self bundlePath] lastPathComponent];
+            if (!appBinaryPath || !appBundleFileName) return nil;
+            
+            NSString* appBinaryChecksum = [[NSFileManager defaultManager] checksum:NSChecksumTypeMD5 ofFileAtPath:appBinaryPath];
+            if (!appBinaryChecksum) return nil;
+            
+            NSString* applicationsFolderPath = @"/Applications/";
+            NSString* desktopFolderPath = [NSString stringWithFormat:@"%@/Desktop/",NSHomeDirectory()];
+            NSString* downloadsFolderPath = [NSString stringWithFormat:@"%@/Downloads/",NSHomeDirectory()];
+            
+            NSString* applicationInDesktopFolderPath = [desktopFolderPath stringByAppendingString:appBundleFileName];
+            if ([self doesBundleAtPath:applicationInDesktopFolderPath executableMatchesWithMD5Checksum:appBinaryChecksum])
+            {
+                bundlePathBeforeAppTranslocation = applicationInDesktopFolderPath;
+            }
+            
+            if (bundlePathBeforeAppTranslocation == nil)
+            {
+                NSString* applicationInDownloadsFolderPath = [downloadsFolderPath stringByAppendingString:appBundleFileName];
+                if ([self doesBundleAtPath:applicationInDownloadsFolderPath executableMatchesWithMD5Checksum:appBinaryChecksum])
+                {
+                    bundlePathBeforeAppTranslocation = applicationInDownloadsFolderPath;
+                }
+            }
+            
+            if (bundlePathBeforeAppTranslocation == nil)
+            {
+                NSString* applicationInApplicationsFolderPath = [applicationsFolderPath stringByAppendingString:appBundleFileName];
+                if ([self doesBundleAtPath:applicationInApplicationsFolderPath executableMatchesWithMD5Checksum:appBinaryChecksum])
+                {
+                    bundlePathBeforeAppTranslocation = applicationInApplicationsFolderPath;
+                }
+            }
+            
+            if (bundlePathBeforeAppTranslocation == nil)
+            {
+                NSArray* desktopFilesMatches = [[NSFileManager defaultManager] subpathsAtPath:desktopFolderPath
+                                                                                 ofFilesNamed:appBundleFileName];
+                for (NSString* desktopFilesMatch in desktopFilesMatches)
+                {
+                    if ([self doesBundleAtPath:desktopFilesMatch executableMatchesWithMD5Checksum:appBinaryChecksum])
+                    {
+                        bundlePathBeforeAppTranslocation = desktopFilesMatch;
+                        break;
+                    }
+                }
+            }
+            
+            if (bundlePathBeforeAppTranslocation == nil)
+            {
+                NSArray* downloadsFilesMatches = [[NSFileManager defaultManager] subpathsAtPath:downloadsFolderPath
+                                                                                   ofFilesNamed:appBundleFileName];
+                for (NSString* downloadsFilesMatch in downloadsFilesMatches)
+                {
+                    if ([self doesBundleAtPath:downloadsFilesMatch executableMatchesWithMD5Checksum:appBinaryChecksum])
+                    {
+                        bundlePathBeforeAppTranslocation = downloadsFilesMatch;
+                        break;
+                    }
+                }
+            }
+            
+            if (bundlePathBeforeAppTranslocation == nil)
+            {
+                NSArray* applicationsFilesMatches = [[NSFileManager defaultManager] subpathsAtPath:applicationsFolderPath
+                                                                                      ofFilesNamed:appBundleFileName];
+                for (NSString* applicationsFilesMatch in applicationsFilesMatches)
+                {
+                    if ([self doesBundleAtPath:applicationsFilesMatch executableMatchesWithMD5Checksum:appBinaryChecksum])
+                    {
+                        bundlePathBeforeAppTranslocation = applicationsFilesMatch;
+                        break;
+                    }
+                }
+            }
+            
+            if (bundlePathBeforeAppTranslocation == nil)
+            {
+                NSArray* homeFilesMatches = [[NSFileManager defaultManager] subpathsAtPath:@"~" ofFilesNamed:appBundleFileName];
+                
+                for (NSString* homeFilesMatch in homeFilesMatches)
+                {
+                    if ([self doesBundleAtPath:homeFilesMatch executableMatchesWithMD5Checksum:appBinaryChecksum])
+                    {
+                        bundlePathBeforeAppTranslocation = homeFilesMatch;
+                        break;
+                    }
+                }
+            }
+            
+            if (bundlePathBeforeAppTranslocation == nil)
+            {
+                NSArray* diskFilesMatches = [[NSFileManager defaultManager] subpathsAtPath:@"/" ofFilesNamed:appBundleFileName];
+                
+                for (NSString* diskFilesMatch in diskFilesMatches)
+                {
+                    if ([self doesBundleAtPath:diskFilesMatch executableMatchesWithMD5Checksum:appBinaryChecksum])
+                    {
+                        bundlePathBeforeAppTranslocation = diskFilesMatch;
+                        break;
+                    }
+                }
+            }
+        }
+        
+        return bundlePathBeforeAppTranslocation;
+    }
+}
+
+-(BOOL)isAppTranslocationActive
+{
+    // App Translocation description:
+    // http://lapcatsoftware.com/articles/app-translocation.html
+    
+    if (!IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR) return false;
+    
+    NSString* path = [self bundlePath];
+    return [path hasPrefix:@"/private/var/folders/"] || [path hasPrefix:@"/var/folders/"];
+}
+-(BOOL)disableAppTranslocation
+{
+    NSString* originalPath = [self bundlePath];
+    if (originalPath == nil) return false;
+    
+    [NSTask runProgram:@"xattr" withFlags:@[@"-r",@"-d",@"com.apple.quarantine",originalPath]];
+    return true;
+}
+
++(nullable NSBundle*)originalMainBundle
+{
+    @synchronized ([NSBundle class])
+    {
+        if ([[NSBundle mainBundle] isAppTranslocationActive])
+        {
+            if (_originalMainBundle != nil && [[NSFileManager defaultManager] fileExistsAtPath:_originalMainBundle.bundlePath])
+            {
+                return _originalMainBundle;
+            }
+            
+            NSString* originalPath = [[NSBundle mainBundle] bundlePathBeforeAppTranslocation];
+            if (originalPath == nil)
+            {
+                return nil;
+            }
+            
+            _originalMainBundle = [NSBundle bundleWithPath:originalPath];
+            return _originalMainBundle;
+        }
+        
+        return [NSBundle mainBundle];
+    }
+}
+
+-(BOOL)preferExternalGPU
+{
+    NSUserDefaults* defaults = [self userDefaults];
+    return [defaults preferExternalGPU];
+}
+-(void)setPreferExternalGPU:(BOOL)prefer
+{
+    NSUserDefaults* defaults = [self userDefaults];
+    [defaults setPreferExternalGPU:prefer];
+    [defaults synchronize];
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSColor+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSColor+Extension.h
@@ -1,0 +1,19 @@
+//
+//  NSColor+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 31/08/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+NSColor* _Nullable RGBA(CGFloat r, CGFloat g, CGFloat b, CGFloat a);
+NSColor* _Nullable RGB(CGFloat r, CGFloat g, CGFloat b);
+
+@interface NSColor (VMMColor)
+
++(nullable NSColor*)colorWithHexColorString:(nonnull NSString*)inColorString;
+-(nullable NSString*)hexColorString;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSColor+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSColor+Extension.m
@@ -1,0 +1,89 @@
+//
+//  NSColor+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 31/08/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSColor+Extension.h"
+#import "NSException+Extension.h"
+
+NSColor* _Nullable RGBA(CGFloat r, CGFloat g, CGFloat b, CGFloat a)
+{
+    return [NSColor colorWithDeviceRed:r/255.0 green:g/255.0 blue:b/255.0 alpha:a/255.0];
+}
+
+NSColor* _Nullable RGB(CGFloat r, CGFloat g, CGFloat b)
+{
+    return RGBA(r,g,b,255.0);
+}
+
+@implementation NSColor (VMMColor)
+
++(nullable NSColor*)colorWithHexColorString:(nonnull NSString*)inColorString
+{
+    NSColor* result = nil;
+    
+    @autoreleasepool
+    {
+        unsigned colorCode = 0;
+        unsigned char redByte, greenByte, blueByte;
+        
+        if (inColorString.length == 7 && [inColorString hasPrefix:@"#"])
+        {
+            inColorString = [inColorString substringFromIndex:1];
+        }
+        
+        if (inColorString.length != 6)
+        {
+            @throw exception(NSInvalidArgumentException,
+                             @"colorWithHexColorString: only accepts hexadecimal colors, with 6 or 7 characters (eg. 000000 or #000000)");
+        }
+        
+        NSScanner* scanner = [NSScanner scannerWithString:inColorString];
+        (void) [scanner scanHexInt:&colorCode]; // ignore error
+        
+        redByte = (unsigned char)(colorCode >> 16);
+        greenByte = (unsigned char)(colorCode >> 8);
+        blueByte = (unsigned char)(colorCode); // masks off high bits
+        
+        result = RGB((CGFloat)redByte, (CGFloat)greenByte, (CGFloat)blueByte);
+    }
+    
+    return result;
+}
+-(nullable NSString*)hexColorString
+{
+    NSString* result = nil;
+    
+    @autoreleasepool
+    {
+        // https://developer.apple.com/library/content/qa/qa1576/_index.html
+        
+        NSString *redHexValue,  *greenHexValue,  *blueHexValue;
+        CGFloat   redFloatValue, greenFloatValue, blueFloatValue;
+        int        redIntValue,  greenIntValue,   blueIntValue;
+        
+        NSColor *convertedColor = [self colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
+        
+        if (convertedColor != nil)
+        {
+            [convertedColor getRed:&redFloatValue green:&greenFloatValue blue:&blueFloatValue alpha:NULL];
+            
+            redIntValue   = redFloatValue   * 255.99999f;
+            greenIntValue = greenFloatValue * 255.99999f;
+            blueIntValue  = blueFloatValue  * 255.99999f;
+            
+            redHexValue   = [NSString stringWithFormat:@"%02x", redIntValue];
+            greenHexValue = [NSString stringWithFormat:@"%02x", greenIntValue];
+            blueHexValue  = [NSString stringWithFormat:@"%02x", blueIntValue];
+            
+            result = [NSString stringWithFormat:@"%@%@%@", redHexValue, greenHexValue, blueHexValue];
+        }
+    }
+    
+    return result;
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSData+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSData+Extension.h
@@ -1,0 +1,27 @@
+//
+//  NSData+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#ifndef NSData_Extension_Class
+#define NSData_Extension_Class
+
+#import <Foundation/Foundation.h>
+
+@interface NSData (VMMData)
+
++(void)dataWithContentsOfURL:(nonnull NSURL *)url timeoutInterval:(long long int)timeoutInterval withCompletionHandler:(void (^_Nullable)(NSUInteger statusCode, NSData* _Nullable data, NSError* _Nullable error))completion;
++(nullable NSData*)safeDataWithContentsOfFile:(nonnull NSString*)filePath;
+
++(nullable NSString*)jsonStringWithObject:(nonnull id)object;
++(nullable NSData*)jsonDataWithObject:(nonnull id)object;
+-(nullable id)objectWithJsonData;
+
+-(nonnull NSString*)base64EncodedString;
+
+@end
+
+#endif

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSData+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSData+Extension.m
@@ -1,0 +1,156 @@
+//
+//  NSData+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSData+Extension.h"
+
+#import "SZJsonParser.h"
+
+#import "VMMAlert.h"
+#import "NSMutableString+Extension.h"
+
+#import "VMMComputerInformation.h"
+#import "VMMLocalizationUtility.h"
+
+@implementation NSData (VMMData)
+
++(void)dataWithContentsOfURL:(nonnull NSURL *)url timeoutInterval:(long long int)timeoutInterval withCompletionHandler:(void (^_Nullable)(NSUInteger statusCode, NSData* _Nullable data, NSError* _Nullable error))completion
+{
+    NSData* stringData;
+    
+    @autoreleasepool
+    {
+        NSURLRequest* request = [NSURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
+                                             timeoutInterval:timeoutInterval];
+        
+        NSError *error = nil;
+        NSHTTPURLResponse *response = nil;
+        stringData = [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:&error];
+        
+        if (completion != nil) {
+            completion(response.statusCode, stringData, error);
+        }
+    }
+}
++(nullable NSData*)safeDataWithContentsOfFile:(nonnull NSString*)filePath
+{
+    if (![[NSFileManager defaultManager] fileExistsAtPath:filePath]) return nil;
+    
+    NSData* data;
+    
+    @autoreleasepool
+    {
+        NSError *error = nil;
+        data = [[NSData alloc] initWithContentsOfFile:filePath options:0 error:&error];
+        
+        if (error != nil)
+        {
+            [VMMAlert showAlertOfType:VMMAlertTypeError withMessage:[NSString stringWithFormat:VMMLocalizedString(@"Error while loading file data: %@"), error.localizedDescription]];
+        }
+    }
+    
+    return data;
+}
+
++(nullable NSString*)jsonStringWithObject:(nonnull id)object
+{
+    if (IsClassNSJSONSerializationAvailable == false)
+    {
+        @autoreleasepool
+        {
+            if ([object isKindOfClass:[NSString class]])
+            {
+                NSMutableString* stringObject = [(NSString*)object mutableCopy];
+                [stringObject replaceOccurrencesOfString:@"\"" withString:@"\\\""];
+                [stringObject replaceOccurrencesOfString:@"\n" withString:@"\\\n"];
+                [stringObject replaceOccurrencesOfString:@"/"  withString:@"\\/" ];
+                return [NSString stringWithFormat:@"\"%@\"",stringObject];
+            }
+            
+            if ([object isKindOfClass:[NSArray class]])
+            {
+                NSMutableArray* array = [[NSMutableArray alloc] init];
+                for (id innerObject in (NSArray*)object)
+                {
+                    [array addObject:[self jsonStringWithObject:innerObject]];
+                }
+                return [NSString stringWithFormat:@"[%@]",[array componentsJoinedByString:@","]];
+            }
+            
+            if ([object isKindOfClass:[NSDictionary class]])
+            {
+                NSMutableArray* dict = [[NSMutableArray alloc] init];
+                for (NSString* key in [(NSDictionary*)object allKeys])
+                {
+                    [dict addObject:[NSString stringWithFormat:@"%@:%@",[self jsonStringWithObject:key],
+                                     [self jsonStringWithObject:[(NSDictionary*)object objectForKey:key]]]];
+                }
+                return [NSString stringWithFormat:@"{%@}",[dict componentsJoinedByString:@","]];
+            }
+            
+            if ([object isKindOfClass:[NSNumber class]])
+            {
+                NSInteger integerValue = [(NSNumber*)object integerValue];
+                double doubleValue = [(NSNumber*)object doubleValue];
+                BOOL boolValue = [(NSNumber*)object boolValue];
+                
+                if (integerValue != doubleValue) return [NSString stringWithFormat:@"%lf",doubleValue];
+                if (integerValue != boolValue)   return [NSString stringWithFormat:@"%ld",integerValue];
+                return boolValue ? @"true" : @"false";
+            }
+            
+            return @"";
+        }
+    }
+
+    return [[NSString alloc] initWithData:[self jsonDataWithObject:object] encoding:NSUTF8StringEncoding];
+}
+
++(nullable NSData*)jsonDataWithObject:(nonnull id)object
+{
+    if (IsClassNSJSONSerializationAvailable == false)
+    {
+        @autoreleasepool
+        {
+            return [[self jsonStringWithObject:object] dataUsingEncoding:NSUTF8StringEncoding];
+        }
+    }
+    
+    return [NSJSONSerialization dataWithJSONObject:object options:NSJSONWritingPrettyPrinted error:nil];
+}
+
+-(nullable id)objectWithJsonData
+{
+    if (IsClassNSJSONSerializationAvailable == false)
+    {
+        @autoreleasepool
+        {
+            @try
+            {
+                return [[[NSString alloc] initWithData:self encoding:NSUTF8StringEncoding] jsonObject];
+            }
+            @catch (NSException* exception)
+            {
+                return nil;
+            }
+        }
+    }
+
+    return [NSJSONSerialization JSONObjectWithData:self options:0 error:nil];
+}
+
+-(nonnull NSString*)base64EncodedString
+{
+    if (![self respondsToSelector:@selector(base64EncodedStringWithOptions:)])
+    {
+        return [self base64Encoding];
+    }
+    
+    return [self base64EncodedStringWithOptions:0];
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSDateFormatter+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSDateFormatter+Extension.h
@@ -1,0 +1,15 @@
+//
+//  NSDateFormatter+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 21/07/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSDateFormatter (VMMDateFormatter)
+
++(nullable NSDate*)dateFromString:(nonnull NSString *)string withFormat:(nonnull NSString*)format;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSDateFormatter+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSDateFormatter+Extension.m
@@ -1,0 +1,20 @@
+//
+//  NSDateFormatter+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 21/07/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSDateFormatter+Extension.h"
+
+@implementation NSDateFormatter (VMMDateFormatter)
+
++(nullable NSDate*)dateFromString:(nonnull NSString *)string withFormat:(nonnull NSString*)format
+{
+    NSDateFormatter *df = [[NSDateFormatter alloc] init];
+    [df setDateFormat:format];
+    return [df dateFromString:string];
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSException+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSException+Extension.h
@@ -1,0 +1,15 @@
+//
+//  NSException+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 19/12/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NSException* exception(NSString* name, NSString* reason);
+
+@interface NSException (VMMException)
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSException+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSException+Extension.m
@@ -1,0 +1,18 @@
+//
+//  NSException+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 19/12/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import "NSException+Extension.h"
+
+NSException* exception(NSString* name, NSString* reason)
+{
+    return [NSException exceptionWithName:name reason:reason userInfo:nil];
+}
+
+@implementation NSException (VMMException)
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSFileManager+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSFileManager+Extension.h
@@ -1,0 +1,58 @@
+//
+//  NSFileManager+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#ifndef NSFileManager_Extension_Class
+#define NSFileManager_Extension_Class
+
+#import <Foundation/Foundation.h>
+
+typedef enum NSChecksumType
+{
+    NSChecksumTypeGOSTMac,
+    NSChecksumTypeStreebog512,
+    NSChecksumTypeStreebog256,
+    NSChecksumTypeGOST94,
+    NSChecksumTypeMD4,
+    NSChecksumTypeMD5,
+    NSChecksumTypeRIPEMD160,
+    NSChecksumTypeSHA,
+    NSChecksumTypeSHA1,
+    NSChecksumTypeSHA224,
+    NSChecksumTypeSHA256,
+    NSChecksumTypeSHA384,
+    NSChecksumTypeSHA512,
+    NSChecksumTypeWrirlpool
+} NSChecksumType;
+
+@interface NSFileManager (VMMFileManager)
+
+-(BOOL)createSymbolicLinkAtPath:(nonnull NSString *)path withDestinationPath:(nonnull NSString *)destPath;
+-(BOOL)createDirectoryAtPath:(nonnull NSString*)path withIntermediateDirectories:(BOOL)interDirs;
+-(BOOL)createEmptyFileAtPath:(nonnull NSString*)path;
+
+-(BOOL)moveItemAtPath:(nonnull NSString*)path toPath:(nonnull NSString*)destination;
+-(BOOL)copyItemAtPath:(nonnull NSString*)path toPath:(nonnull NSString*)destination;
+-(BOOL)removeItemAtPath:(nonnull NSString*)path;
+-(BOOL)directoryExistsAtPath:(nonnull NSString*)path;
+-(BOOL)regularFileExistsAtPath:(nonnull NSString*)path;
+-(nullable NSArray<NSString*>*)contentsOfDirectoryAtPath:(nonnull NSString*)path;
+-(nullable NSArray<NSString*>*)subpathsAtPath:(nonnull NSString *)path ofFilesNamed:(nonnull NSString*)fileName;
+-(nullable NSString*)destinationOfSymbolicLinkAtPath:(nonnull NSString *)path;
+
+-(nullable NSString*)userReadablePathForItemAtPath:(nonnull NSString*)path joinedByString:(nullable NSString*)join;
+
+-(unsigned long long int)sizeOfRegularFileAtPath:(nonnull NSString*)path;
+-(unsigned long long int)sizeOfDirectoryAtPath:(nonnull NSString*)path;
+
+-(nullable NSString*)checksum:(NSChecksumType)checksum ofFileAtPath:(nonnull NSString*)file;
+
+-(nullable NSString*)base64OfFileAtPath:(nonnull NSString*)path;
+
+@end
+
+#endif

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSFileManager+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSFileManager+Extension.m
@@ -1,0 +1,250 @@
+//
+//  NSFileManager+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSFileManager+Extension.h"
+
+#import "VMMAlert.h"
+#import "NSArray+Extension.h"
+#import "NSData+Extension.h"
+#import "NSTask+Extension.h"
+#import "NSString+Extension.h"
+#import "NSThread+Extension.h"
+
+#import "VMMComputerInformation.h"
+#import "VMMLocalizationUtility.h"
+
+@implementation NSFileManager (VMMFileManager)
+
+-(BOOL)createSymbolicLinkAtPath:(nonnull NSString *)path withDestinationPath:(nonnull NSString *)destPath
+{
+    NSError* error;
+    BOOL created = [self createSymbolicLinkAtPath:path withDestinationPath:destPath error:&error];
+    
+    if (error != nil)
+    {
+        [VMMAlert showAlertOfType:VMMAlertTypeError withMessage:[NSString stringWithFormat:VMMLocalizedString(@"Error while creating symbolic link: %@"), error.localizedDescription]];
+    }
+    
+    return created;
+}
+-(BOOL)createDirectoryAtPath:(nonnull NSString*)path withIntermediateDirectories:(BOOL)interDirs
+{
+    NSError* error;
+    BOOL created = [self createDirectoryAtPath:path withIntermediateDirectories:interDirs attributes:nil error:&error];
+    
+    if (error != nil)
+    {
+        [VMMAlert showAlertOfType:VMMAlertTypeError withMessage:[NSString stringWithFormat:VMMLocalizedString(@"Error while creating folder: %@"), error.localizedDescription]];
+    }
+    
+    return created;
+}
+-(BOOL)createEmptyFileAtPath:(nonnull NSString*)path
+{
+    return [self createFileAtPath:path contents:nil attributes:nil];
+}
+
+-(BOOL)moveItemAtPath:(nonnull NSString*)path toPath:(nonnull NSString*)destination
+{
+    NSError* error;
+    BOOL created = [self moveItemAtPath:path toPath:destination error:&error];
+    
+    if (error != nil)
+    {
+        [VMMAlert showAlertOfType:VMMAlertTypeError
+            withMessage:[NSString stringWithFormat:VMMLocalizedString(@"Error while moving file: %@"), error.localizedDescription]];
+    }
+    
+    return created;
+}
+-(BOOL)copyItemAtPath:(nonnull NSString*)path toPath:(nonnull NSString*)destination
+{
+    NSError* error;
+    BOOL created = [self copyItemAtPath:path toPath:destination error:&error];
+    
+    if (error != nil)
+    {
+        [VMMAlert showAlertOfType:VMMAlertTypeError withMessage:[NSString stringWithFormat:VMMLocalizedString(@"Error while copying file: %@"), error.localizedDescription]];
+    }
+    
+    return created;
+}
+-(BOOL)removeItemAtPath:(nonnull NSString*)path
+{
+    if ([self fileExistsAtPath:path] == false) return YES;
+    
+    NSError* error;
+    BOOL created = [self removeItemAtPath:path error:&error];
+    
+    if (error != nil)
+    {
+        [VMMAlert showAlertOfType:VMMAlertTypeError withMessage:[NSString stringWithFormat:VMMLocalizedString(@"Error while removing file: %@"), error.localizedDescription]];
+    }
+    
+    return created;
+}
+-(BOOL)directoryExistsAtPath:(nonnull NSString*)path
+{
+    BOOL isDir = NO;
+    return [self fileExistsAtPath:path isDirectory:&isDir] && isDir;
+}
+-(BOOL)regularFileExistsAtPath:(nonnull NSString*)path
+{
+    BOOL isDir = NO;
+    return [self fileExistsAtPath:path isDirectory:&isDir] && !isDir;
+}
+-(nullable NSArray<NSString*>*)contentsOfDirectoryAtPath:(nonnull NSString*)path
+{
+    if (![self fileExistsAtPath:path])
+    {
+        [VMMAlert showAlertOfType:VMMAlertTypeError withMessage:[NSString stringWithFormat:VMMLocalizedString(@"Error while listing folder contents: %@ doesn't exist."), path.lastPathComponent]];
+        return @[];
+    }
+    
+    if (![self directoryExistsAtPath:path])
+    {
+        [VMMAlert showAlertOfType:VMMAlertTypeError withMessage:[NSString stringWithFormat:VMMLocalizedString(@"Error while listing folder contents: %@ is not a folder."), path.lastPathComponent]];
+        return @[];
+    }
+    
+    NSError* error;
+    NSArray* created = [self contentsOfDirectoryAtPath:path error:&error];
+    
+    if (error != nil)
+    {
+        [VMMAlert showAlertOfType:VMMAlertTypeError withMessage:[NSString stringWithFormat:VMMLocalizedString(@"Error while listing folder contents: %@"), error.localizedDescription]];
+        return @[];
+    }
+    
+    NSMutableArray* createdMutable = [created mutableCopy];
+    [createdMutable removeObject:@".DS_Store"];
+    
+    return createdMutable;
+}
+-(nullable NSArray<NSString*>*)subpathsAtPath:(nonnull NSString *)path ofFilesNamed:(nonnull NSString*)fileName
+{
+    @autoreleasepool
+    {
+        return [[[[NSTask runProgram:@"find" withFlags:@[path,@"-name",fileName]] componentsSeparatedByString:@"\n"]
+                    filter:^BOOL(NSString* object) { return ![object hasPrefix:@"find: "]; }]
+                       map:^id(NSString* object)   { return  [object stringByReplacingOccurrencesOfString:@"//" withString:@"/"];}];
+    }
+}
+-(nullable NSString*)destinationOfSymbolicLinkAtPath:(nonnull NSString *)path
+{
+    NSError* error;
+    NSString* destination = [self destinationOfSymbolicLinkAtPath:path error:&error];
+    
+    if (error != nil)
+    {
+        [VMMAlert showAlertOfType:VMMAlertTypeError withMessage:[NSString stringWithFormat:VMMLocalizedString(@"Error while retrieving symbolic link destination: %@"),error.localizedDescription]];
+    }
+    
+    return destination;
+}
+
+-(nullable NSString*)userReadablePathForItemAtPath:(nonnull NSString*)path joinedByString:(nullable NSString*)join
+{
+    NSArray* components = [self componentsToDisplayForPath:path];
+    
+    if (join == nil) join = @" → ";
+    
+    if (([self fileExistsAtPath:path] == false) || (components == nil))
+    {
+        return [NSString stringWithFormat:@"%@%@%@",[self userReadablePathForItemAtPath:path.stringByDeletingLastPathComponent
+                                                                         joinedByString:join], join, path.lastPathComponent];
+    }
+    
+    return [components componentsJoinedByString:join];
+}
+
+-(unsigned long long int)sizeOfRegularFileAtPath:(nonnull NSString*)path
+{
+    unsigned long long int result = 0;
+    
+    @autoreleasepool
+    {
+        NSDictionary *fileDictionary = [self attributesOfItemAtPath:path error:nil];
+        if (fileDictionary != nil) result = [fileDictionary[NSFileSize] unsignedLongLongValue];
+    }
+    
+    return result;
+}
+-(unsigned long long int)sizeOfDirectoryAtPath:(nonnull NSString*)path
+{
+    unsigned long long int fileSize = 0;
+    
+    @autoreleasepool
+    {
+        NSArray *filesArray = [[NSFileManager defaultManager] subpathsOfDirectoryAtPath:path error:nil];
+        
+        for (NSString* file in filesArray)
+        {
+            NSString* filePath = [path stringByAppendingPathComponent:file];
+            
+            if (![self destinationOfSymbolicLinkAtPath:filePath error:nil])
+            {
+                fileSize += [self sizeOfRegularFileAtPath:filePath];
+            }
+        }
+    }
+    
+    return fileSize;
+}
+
+-(nullable NSString*)checksum:(NSChecksumType)checksum ofFileAtPath:(nonnull NSString*)file
+{
+    NSString* result;
+    
+    @autoreleasepool
+    {
+        NSString* algorithm;
+        
+        switch (checksum)
+        {
+            case NSChecksumTypeGOSTMac:     algorithm = @"-gost-mac";    break;
+            case NSChecksumTypeStreebog512: algorithm = @"-streebog512"; break;
+            case NSChecksumTypeStreebog256: algorithm = @"-streebog256"; break;
+            case NSChecksumTypeGOST94:      algorithm = @"-md_gost94";   break;
+            case NSChecksumTypeMD4:         algorithm = @"-md4";         break;
+            case NSChecksumTypeMD5:         algorithm = @"-md5";         break;
+            case NSChecksumTypeRIPEMD160:   algorithm = @"-ripemd160";   break;
+            case NSChecksumTypeSHA:         algorithm = @"-sha";         break;
+            case NSChecksumTypeSHA1:        algorithm = @"-sha1";        break;
+            case NSChecksumTypeSHA224:      algorithm = @"-sha224";      break;
+            case NSChecksumTypeSHA256:      algorithm = @"-sha256";      break;
+            case NSChecksumTypeSHA384:      algorithm = @"-sha384";      break;
+            case NSChecksumTypeSHA512:      algorithm = @"-sha512";      break;
+            case NSChecksumTypeWrirlpool:   algorithm = @"-whirlpool";   break;
+            default: return nil;
+        }
+        
+        NSString* output = [NSTask runCommand:@[@"openssl", @"dgst", algorithm, file]];
+        if (output == nil) return nil;
+        
+        NSRange lastSpaceRange = [output rangeOfString:@" " options:NSBackwardsSearch];
+        if (lastSpaceRange.location == NSNotFound) return nil;
+        
+        CGFloat checkSumWithSkipLineStartLocation = lastSpaceRange.location + lastSpaceRange.length;
+        NSRange checkSumWithSkipLineStartRange = NSMakeRange(checkSumWithSkipLineStartLocation, output.length - checkSumWithSkipLineStartLocation);
+        
+        NSRange checkSumWithSkipLineEndRange = [output rangeOfString:@"\n" options:0 range:checkSumWithSkipLineStartRange];
+        CGFloat checkSumWithSkipLineLength = checkSumWithSkipLineEndRange.location - checkSumWithSkipLineStartLocation;
+        
+        result = [output substringWithRange:NSMakeRange(checkSumWithSkipLineStartLocation, checkSumWithSkipLineLength)];
+    }
+    
+    return result;
+}
+
+-(nullable NSString*)base64OfFileAtPath:(nonnull NSString*)path
+{
+    return [[NSData dataWithContentsOfFile:path] base64EncodedString];
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSImage+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSImage+Extension.h
@@ -1,0 +1,39 @@
+//
+//  NSImage+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 12/03/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#ifndef NSImage_Extension_Class
+#define NSImage_Extension_Class
+
+#import <Cocoa/Cocoa.h>
+
+@interface NSBitmapImageRep (VMMBitmapImageRep)
+
+-(BOOL)isTransparentAtX:(int)x andY:(int)y;
+
+@end
+
+
+@interface NSImage (VMMImage)
+
++(NSImage*)imageWithData:(NSData*)data;
+
++(NSImage*)quickLookImageWithMaximumSize:(int)size forFileAtPath:(NSString*)arquivo;
++(NSImage*)imageFromFileAtPath:(NSString*)arquivo;
+
++(NSImage*)transparentImageWithSize:(NSSize)size;
+
+-(BOOL)isTransparent;
+
+-(BOOL)saveAsIcnsAtPath:(NSString*)icnsPath;
+
+-(NSData*)dataForImageWithType:(NSBitmapImageFileType)type;
+-(BOOL)writeToFile:(NSString*)file atomically:(BOOL)useAuxiliaryFile;
+
+@end
+
+#endif

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSImage+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSImage+Extension.m
@@ -1,0 +1,256 @@
+//
+//  NSImage+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 12/03/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import <CoreImage/CoreImage.h>
+
+#import "NSException+Extension.h"
+#import "NSFileManager+Extension.h"
+#import "NSImage+Extension.h"
+#import "NSString+Extension.h"
+#import "NSTask+Extension.h"
+#import "NSScreen+Extension.h"
+
+#import "VMMComputerInformation.h"
+#import "VMMLogUtility.h"
+
+#define SMALLER_ICONSET_NEEDED_SIZE 16
+#define BIGGEST_ICONSET_NEEDED_SIZE 1024
+
+#define TIFF2ICNS_ICON_SIZE 512
+
+@implementation NSBitmapImageRep (VMMBitmapImageRep)
+-(BOOL)isTransparentAtX:(int)x andY:(int)y
+{
+    CGFloat alpha = [[self colorAtX:x y:y] alphaComponent];
+    return (alpha < 1.0/255);
+}
+@end
+
+@implementation NSImage (VMMImage)
+
++(NSImage*)imageWithData:(NSData*)data
+{
+    NSImage* image;
+    
+    @try
+    {
+        image = [[NSImage alloc] initWithData:data];
+    }
+    @catch (NSException* exception)
+    {
+        return nil;
+    }
+    
+    return image;
+}
+
++(NSImage*)quickLookImageWithMaximumSize:(int)size forFileAtPath:(NSString*)arquivo
+{
+    NSImage* img;
+    
+    @autoreleasepool
+    {
+        img = [[NSWorkspace sharedWorkspace] iconForFile:arquivo];
+        
+        [NSTask runCommand:@[@"qlmanage", @"-t", @"-s",[NSString stringWithFormat:@"%d",size], @"-o.", arquivo]
+                 atRunPath:[arquivo stringByDeletingLastPathComponent]];
+        
+        NSString* newFile = [NSString stringWithFormat:@"%@.png",arquivo];
+        if ([[NSFileManager defaultManager] regularFileExistsAtPath:newFile])
+        {
+            img = [[NSImage alloc] initWithContentsOfFile:newFile];
+            [[NSFileManager defaultManager] removeItemAtPath:newFile];
+        }
+    }
+    
+    return img;
+}
++(NSImage*)imageFromFileAtPath:(NSString*)arquivo
+{
+    NSImage *img;
+    
+    @autoreleasepool
+    {
+        if ([[NSImage imageFileTypes] containsObject:arquivo.pathExtension.lowercaseString])
+        {
+            img = [[NSImage alloc] initWithContentsOfFile:arquivo];
+        }
+        
+        if (img == nil)
+        {
+            // 100000 is an arbitrary number, choosen for been a size bigger enought to
+            // take the maximum quality of every possible image or icon.
+            img = [self quickLookImageWithMaximumSize:100000 forFileAtPath:arquivo];
+        }
+        
+        if (img == nil)
+        {
+            img = [[NSWorkspace sharedWorkspace] iconForFile:arquivo];
+        }
+    }
+    
+    return img;
+}
+
++(NSImage*)transparentImageWithSize:(NSSize)size
+{
+    NSImage* clearImage = [[NSImage alloc] initWithSize:size];
+    [clearImage lockFocus];
+    [[NSColor clearColor] setFill];
+    [NSBezierPath fillRect:NSMakeRect(0, 0, size.height, size.width)];
+    [clearImage unlockFocus];
+    
+    return clearImage;
+}
+
+-(BOOL)isTransparent
+{
+    @autoreleasepool
+    {
+        NSData *tempData = [[NSData alloc] initWithData:[self TIFFRepresentation]];
+        NSBitmapImageRep *repIcon = [[NSBitmapImageRep alloc] initWithData:tempData];
+        int x, y;
+        
+        for (y=0; y<self.size.height; y++)
+        {
+            for (x=0; x<self.size.width; x++)
+            {
+                if ([repIcon isTransparentAtX:x andY:y] == false)
+                {
+                    return false;
+                }
+            }
+        }
+    }
+    
+    return true;
+}
+
+-(BOOL)saveAsPngImageWithSize:(int)size atPath:(NSString*)pngPath
+{
+    @autoreleasepool
+    {
+        CIImage *ciimage = [CIImage imageWithData:[self TIFFRepresentation]];
+        CIFilter *scaleFilter = [CIFilter filterWithName:@"CILanczosScaleTransform"];
+        
+        int originalWidth  = [ciimage extent].size.width;
+        float scale = (float)size / (float)originalWidth;
+        
+        [scaleFilter setValue:@(scale) forKey:@"inputScale"];
+        [scaleFilter setValue:@(1.0)   forKey:@"inputAspectRatio"];
+        [scaleFilter setValue:ciimage  forKey:@"inputImage"];
+        
+        ciimage = [scaleFilter valueForKey:@"outputImage"];
+        if (ciimage == nil) return false;
+        
+        NSBitmapImageRep* rep;
+        
+        @try
+        {
+            rep = [[NSBitmapImageRep alloc] initWithCIImage:ciimage];
+        }
+        @catch (NSException* exception)
+        {
+            return false;
+        }
+        
+        NSData *data = [rep representationUsingType:NSPNGFileType properties:@{}];
+        [data writeToFile:pngPath atomically:YES];
+    }
+        
+    return true;
+}
+-(BOOL)saveIconsetWithSize:(int)size atFolder:(NSString*)folder
+{
+    BOOL result = [self saveAsPngImageWithSize:size atPath:[NSString stringWithFormat:@"%@/icon_%dx%d.png",folder,size,size]];
+    if (result == false) return false;
+    
+    result = [self saveAsPngImageWithSize:size*2 atPath:[NSString stringWithFormat:@"%@/icon_%dx%d@2x.png",folder,size,size]];
+    return result;
+}
+-(BOOL)saveAsIcnsAtPath:(NSString*)icnsPath
+{
+    if (icnsPath == nil) return false;
+    
+    BOOL result;
+
+    if (IS_SYSTEM_MAC_OS_10_7_OR_SUPERIOR)
+    {
+        @autoreleasepool
+        {
+            if (![icnsPath hasSuffix:@".icns"]) icnsPath = [icnsPath stringByAppendingString:@".icns"];
+            NSString* iconsetPath = [[icnsPath substringToIndex:icnsPath.length - 5] stringByAppendingString:@".iconset"];
+            
+            [[NSFileManager defaultManager] createDirectoryAtPath:iconsetPath withIntermediateDirectories:NO];
+            for (int validSize = SMALLER_ICONSET_NEEDED_SIZE; validSize <= BIGGEST_ICONSET_NEEDED_SIZE; validSize=validSize*2)
+                [self saveIconsetWithSize:validSize atFolder:iconsetPath];
+            
+            [[NSFileManager defaultManager] removeItemAtPath:icnsPath];
+            [NSTask runCommand:@[@"iconutil", @"-c", @"icns", iconsetPath]];
+            [[NSFileManager defaultManager] removeItemAtPath:iconsetPath];
+            
+            result = ([[NSFileManager defaultManager] sizeOfRegularFileAtPath:icnsPath] > 10);
+        }
+        
+        if (result) return true;
+    }
+    
+    @autoreleasepool
+    {
+        NSString *tiffPath = [NSString stringWithFormat:@"%@.tiff",icnsPath];
+        
+        CGFloat correctIconSize = TIFF2ICNS_ICON_SIZE/[[NSScreen mainScreen] retinaScale];
+        NSImage *resizedImage = [[NSImage alloc] initWithSize:NSMakeSize(correctIconSize,correctIconSize)];
+        [resizedImage lockFocus];
+        [self drawInRect:NSMakeRect(0,0,correctIconSize, correctIconSize) fromRect:self.alignmentRect
+               operation:NSCompositeSourceOver fraction:1.0];
+        [resizedImage unlockFocus];
+        
+        [[resizedImage TIFFRepresentation] writeToFile:tiffPath atomically:YES];
+        [[NSFileManager defaultManager] removeItemAtPath:icnsPath];
+        [NSTask runCommand:@[@"tiff2icns", @"-noLarge", tiffPath, icnsPath]];
+        [[NSFileManager defaultManager] removeItemAtPath:tiffPath];
+        
+        result = [[NSFileManager defaultManager] regularFileExistsAtPath:icnsPath];
+    }
+    
+    return result;
+}
+
+-(NSData*)dataForImageWithType:(NSBitmapImageFileType)type {
+    NSBitmapImageRep *imageRep = [NSBitmapImageRep imageRepWithData:[self TIFFRepresentation]];
+    return [imageRep representationUsingType:type properties:@{}];
+}
+
+-(BOOL)writeToFile:(NSString*)file atomically:(BOOL)useAuxiliaryFile
+{
+    @autoreleasepool
+    {
+        NSString* extension = file.pathExtension.lowercaseString;
+        NSDictionary* typeForExtension = @{@"bmp" : @(IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR ? NSBitmapImageFileTypeBMP      : NSBMPFileType     ),
+                                           @"gif" : @(IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR ? NSBitmapImageFileTypeGIF      : NSGIFFileType     ),
+                                           @"jpg" : @(IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR ? NSBitmapImageFileTypeJPEG     : NSJPEGFileType    ),
+                                           @"jp2" : @(IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR ? NSBitmapImageFileTypeJPEG2000 : NSJPEG2000FileType),
+                                           @"png" : @(IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR ? NSBitmapImageFileTypePNG      : NSPNGFileType     ),
+                                           @"tiff": @(IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR ? NSBitmapImageFileTypeTIFF     : NSTIFFFileType    )};
+        
+        if ([typeForExtension.allKeys containsObject:extension] == false)
+        {
+            @throw exception(NSInvalidArgumentException,
+                             [NSString stringWithFormat:@"Invalid extension for saving image file: %@",extension]);
+            return false;
+        }
+        
+        NSData* data = [self dataForImageWithType:(NSBitmapImageFileType)[typeForExtension[extension] unsignedLongValue]];
+        if (data == nil) return false;
+        
+        return [data writeToFile:file atomically:useAuxiliaryFile];
+    }
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSMenuItem+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSMenuItem+Extension.h
@@ -1,0 +1,15 @@
+//
+//  NSMenuItem+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 30/05/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface NSMenuItem (VMMMenuItem)
+
++(nonnull NSMenuItem*)menuItemWithTitle:(nonnull NSString*)title andAction:(nullable SEL)action forTarget:(nullable id)target;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSMenuItem+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSMenuItem+Extension.m
@@ -1,0 +1,20 @@
+//
+//  NSMenuItem+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 30/05/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSMenuItem+Extension.h"
+
+@implementation NSMenuItem (VMMMenuItem)
+
++(nonnull NSMenuItem*)menuItemWithTitle:(nonnull NSString*)title andAction:(nullable SEL)action forTarget:(nullable id)target
+{
+    NSMenuItem* item = [[NSMenuItem alloc] initWithTitle:title action:action keyEquivalent:@""];
+    [item setTarget:target];
+    return item;
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableArray+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableArray+Extension.h
@@ -1,0 +1,23 @@
+//
+//  NSMutableArray+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 24/07/2017.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSMutableArray<ObjectType> (VMMMutableArray)
+
+-(nonnull NSMutableArray*)map:(_Nullable id (^_Nonnull)(id _Nonnull object))newObjectForObject;
+-(nonnull NSMutableArray*)mapWithIndex:(_Nullable id (^_Nonnull)(id _Nonnull object, NSUInteger index))newObjectForObject;
+-(nonnull NSMutableArray*)filter:(BOOL (^_Nonnull)(id _Nonnull object))newObjectForObject;
+-(nonnull NSMutableArray*)filterWithIndex:(BOOL (^_Nonnull)(id _Nonnull object, NSUInteger index))newObjectForObject;
+
+-(void)sortAlphabeticallyByKey:(nonnull NSString*)key ascending:(BOOL)ascending;
+-(void)sortAlphabeticallyAscending:(BOOL)ascending;
+-(void)sortDictionariesWithKey:(nonnull NSString *)key orderingByValuesOrder:(nonnull NSArray*)value;
+-(void)sortBySelector:(SEL _Nonnull)selector inOrder:(NSArray* _Nonnull)order;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableArray+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableArray+Extension.m
@@ -1,0 +1,120 @@
+//
+//  NSMutableArray+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 24/07/2017.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSMutableArray+Extension.h"
+
+@implementation NSMutableArray (VMMMutableArray)
+
+-(nonnull NSMutableArray*)map:(_Nullable id (^_Nonnull)(id _Nonnull object))newObjectForObject
+{
+    for (NSUInteger index = 0; index < self.count; index++)
+    {
+        id newObject = newObjectForObject([self objectAtIndex:index]);
+        [self replaceObjectAtIndex:index withObject:newObject ? newObject : [NSNull null]];
+    }
+    return self;
+}
+-(nonnull NSMutableArray*)mapWithIndex:(_Nullable id (^_Nonnull)(id _Nonnull object, NSUInteger index))newObjectForObject
+{
+    for (NSUInteger index = 0; index < self.count; index++)
+    {
+        id newObject = newObjectForObject([self objectAtIndex:index], index);
+        [self replaceObjectAtIndex:index withObject:newObject ? newObject : [NSNull null]];
+    }
+    return self;
+}
+-(nonnull NSMutableArray*)filter:(BOOL (^_Nonnull)(id _Nonnull object))newObjectForObject
+{
+    NSUInteger size = self.count;
+    for (NSUInteger index = 0; index < size; index++)
+    {
+        BOOL preserve = newObjectForObject([self objectAtIndex:index]);
+        if (!preserve) {
+            [self removeObjectAtIndex:index];
+            index--;
+            size--;
+        }
+    }
+    return self;
+}
+-(nonnull NSMutableArray*)filterWithIndex:(BOOL (^_Nonnull)(id _Nonnull object, NSUInteger index))newObjectForObject
+{
+    NSUInteger size = self.count;
+    for (NSUInteger index = 0; index < size; index++)
+    {
+        BOOL preserve = newObjectForObject([self objectAtIndex:index], index);
+        if (!preserve) {
+            [self removeObjectAtIndex:index];
+            index--;
+            size--;
+        }
+    }
+    return self;
+}
+
+-(void)sortAlphabeticallyByKey:(nonnull NSString*)key ascending:(BOOL)ascending
+{
+    NSSortDescriptor *sort = [NSSortDescriptor sortDescriptorWithKey:key ascending:ascending selector:@selector(caseInsensitiveCompare:)];
+    [self sortUsingDescriptors:@[sort]];
+}
+-(void)sortAlphabeticallyAscending:(BOOL)ascending
+{
+    NSSortDescriptor *sort = [NSSortDescriptor sortDescriptorWithKey:nil ascending:ascending selector:@selector(caseInsensitiveCompare:)];
+    [self sortUsingDescriptors:@[sort]];
+}
+-(void)sortDictionariesWithKey:(nonnull NSString *)key orderingByValuesOrder:(nonnull NSArray*)value
+{
+    [self sortUsingComparator:^NSComparisonResult(NSDictionary* obj1, NSDictionary* obj2)
+    {
+        NSUInteger obj1ValueIndex = obj1[key] != nil ? [value indexOfObject:obj1[key]] : -1;
+        NSUInteger obj2ValueIndex = obj2[key] != nil ? [value indexOfObject:obj2[key]] : -1;
+         
+        if (obj1ValueIndex == -1 && obj2ValueIndex != -1) return NSOrderedDescending;
+        if (obj1ValueIndex != -1 && obj2ValueIndex == -1) return NSOrderedAscending;
+        if (obj1ValueIndex == -1 && obj2ValueIndex == -1) return NSOrderedSame;
+         
+        if (obj1ValueIndex > obj2ValueIndex) return NSOrderedDescending;
+        if (obj1ValueIndex < obj2ValueIndex) return NSOrderedAscending;
+        return NSOrderedSame;
+    }];
+}
+
+-(void)sortBySelector:(SEL _Nonnull)selector inOrder:(NSArray* _Nonnull)order
+{
+    [self sortUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2)
+    {
+         NSUInteger obj1ValueIndex = -1;
+         NSUInteger obj2ValueIndex = -1;
+         
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+         if ([obj1 respondsToSelector:selector])
+         {
+             id obj1ReturnedValue = [obj1 performSelector:selector];
+             if (obj1ReturnedValue != nil) obj1ValueIndex = [order indexOfObject:obj1ReturnedValue];
+         }
+         
+         if ([obj2 respondsToSelector:selector])
+         {
+             id obj2ReturnedValue = [obj2 performSelector:selector];
+             if (obj2ReturnedValue != nil) obj2ValueIndex = [order indexOfObject:obj2ReturnedValue];
+         }
+#pragma clang diagnostic pop
+         
+         if (obj1ValueIndex == -1 && obj2ValueIndex != -1) return NSOrderedDescending;
+         if (obj1ValueIndex != -1 && obj2ValueIndex == -1) return NSOrderedAscending;
+         if (obj1ValueIndex == -1 && obj2ValueIndex == -1) return NSOrderedSame;
+         
+         if (obj1ValueIndex > obj2ValueIndex) return NSOrderedDescending;
+         if (obj1ValueIndex < obj2ValueIndex) return NSOrderedAscending;
+         return NSOrderedSame;
+    }];
+}
+
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableAttributedString+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableAttributedString+Extension.h
@@ -1,0 +1,37 @@
+//
+//  NSMutableAttributedString+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#ifndef NSMutableAttributedString_Extension_Class
+#define NSMutableAttributedString_Extension_Class
+
+#import <Cocoa/Cocoa.h>
+
+@interface NSMutableAttributedString (VMMMutableAttributedString)
+
+-(instancetype)initWithString:(NSString*)str fontNamed:(NSString*)fontName size:(CGFloat)size;
+
+-(void)replaceOccurrencesOfString:(NSString*)oldString withString:(NSString*)newString;
+
+-(void)addAttribute:(NSString *)name value:(id)value;
+-(void)setRegularFont:(NSString*)regFont boldFont:(NSString*)boldFont italicFont:(NSString*)italicFont boldAndItalicFont:(NSString*)biFont size:(CGFloat)fontSize;
+
+-(void)setTextJustified;
+-(void)setTextAlignment:(NSTextAlignment)textAlignment;
+
+-(void)setFontColor:(NSColor*)color range:(NSRange)range;
+-(void)setFontColor:(NSColor*)color;
+-(void)setFont:(NSFont*)font range:(NSRange)range;
+-(void)setFont:(NSFont*)font;
+
+-(void)appendString:(NSString*)aString;
+
+-(BOOL)adjustExpansionToFitWidth:(CGFloat)width;
+
+@end
+
+#endif

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableAttributedString+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableAttributedString+Extension.m
@@ -1,0 +1,128 @@
+//
+//  NSMutableAttributedString+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSMutableAttributedString+Extension.h"
+
+#import "VMMComputerInformation.h"
+
+@implementation NSMutableAttributedString (VMMMutableAttributedString)
+
+-(instancetype)initWithString:(NSString*)str fontNamed:(NSString*)fontName size:(CGFloat)size
+{
+    self = [self initWithString:str];
+    
+    if (self)
+    {
+        NSFont* font = [NSFont fontWithName:fontName size:size];
+        [self addAttribute:NSFontAttributeName value:font];
+    }
+    
+    return self;
+}
+
+-(void)replaceOccurrencesOfString:(NSString*)oldString withString:(NSString*)newString
+{
+    NSRange downloadRange = [self.string rangeOfString:oldString];
+    while (downloadRange.location != NSNotFound && downloadRange.length != 0)
+    {
+        [self replaceCharactersInRange:downloadRange withString:newString];
+        downloadRange = [self.string rangeOfString:oldString];
+    }
+}
+
+-(void)addAttribute:(NSString *)name value:(id)value
+{
+    [self addAttribute:name value:value range:NSMakeRange(0, self.length)];
+}
+-(void)setRegularFont:(NSString*)regFont boldFont:(NSString*)boldFont italicFont:(NSString*)italicFont boldAndItalicFont:(NSString*)biFont size:(CGFloat)fontSize
+{
+    @autoreleasepool
+    {
+        NSMutableDictionary* fontBoldDictionary = [[NSMutableDictionary alloc] init];
+        NSMutableDictionary* fontItalicDictionary = [[NSMutableDictionary alloc] init];
+        
+        for (int i=0; i< self.length; i++)
+        {
+            NSString *fontName = [[self attribute:NSFontAttributeName atIndex:i effectiveRange:nil] fontName];
+            
+            NSNumber* hasItalic = fontItalicDictionary[fontName];
+            if (hasItalic == nil)
+            {
+                fontItalicDictionary[fontName] = @([[[NSFontManager alloc] init] fontNamed:fontName hasTraits:NSItalicFontMask]);
+                hasItalic = fontItalicDictionary[fontName];
+            }
+            
+            NSNumber* hasBold = fontBoldDictionary[fontName];
+            if (hasBold == nil)
+            {
+                fontBoldDictionary[fontName] = @([[[NSFontManager alloc] init] fontNamed:fontName hasTraits:NSBoldFontMask]);
+                hasBold = fontBoldDictionary[fontName];
+            }
+            
+            fontName = regFont;
+            if (boldFont   && hasBold.boolValue)                        fontName = boldFont;
+            if (italicFont && hasItalic.boolValue)                      fontName = italicFont;
+            if (biFont     && hasBold.boolValue && hasItalic.boolValue) fontName = biFont;
+            
+            [self setFont:[NSFont fontWithName:fontName size:fontSize] range:NSMakeRange(i,1)];
+        }
+    }
+}
+
+-(void)setTextJustified
+{
+    [self setTextAlignment:IS_SYSTEM_MAC_OS_10_11_OR_SUPERIOR ? NSTextAlignmentJustified : NSJustifiedTextAlignment];
+}
+-(void)setTextAlignment:(NSTextAlignment)textAlignment
+{
+    NSMutableParagraphStyle *paragrapStyle = [[NSMutableParagraphStyle alloc] init];
+    paragrapStyle.alignment = textAlignment;
+    [self addAttribute:NSParagraphStyleAttributeName value:paragrapStyle];
+}
+
+-(void)setFontColor:(NSColor*)color range:(NSRange)range
+{
+    [self addAttribute:NSForegroundColorAttributeName value:color range:range];
+}
+-(void)setFontColor:(NSColor*)color
+{
+    [self addAttribute:NSForegroundColorAttributeName value:color];
+}
+-(void)setFont:(NSFont*)font range:(NSRange)range
+{
+    [self addAttribute:NSFontAttributeName value:font range:range];
+}
+-(void)setFont:(NSFont*)font
+{
+    [self addAttribute:NSFontAttributeName value:font];
+}
+
+-(void)appendString:(NSString*)aString
+{
+    [self appendAttributedString:[[NSAttributedString alloc] initWithString:aString]];
+}
+
+-(BOOL)adjustExpansionToFitWidth:(CGFloat)width
+{
+    CGFloat originalWidth = self.size.width;
+    
+    BOOL sizeChanged = false;
+    CGFloat resizeRate = 0.0;
+    
+    if (originalWidth > width)
+    {
+        sizeChanged = true;
+        resizeRate = 1 - originalWidth/width;
+    }
+    
+    [self addAttribute:NSExpansionAttributeName value:@(resizeRate)];
+    return sizeChanged;
+}
+
+@end
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableDictionary+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableDictionary+Extension.h
@@ -1,0 +1,20 @@
+//
+//  NSMutableDictionary+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/07/16.
+//  Copyright © 2016 Vitor Marques de Miranda. All rights reserved.
+//
+
+#ifndef NSMutableDictionary_Extension_Class
+#define NSMutableDictionary_Extension_Class
+
+#import <Foundation/Foundation.h>
+
+@interface NSMutableDictionary (VMMMutableDictionary)
+
++(nullable instancetype)mutableDictionaryWithContentsOfFile:(nonnull NSString*)filePath;
+
+@end
+
+#endif

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableDictionary+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableDictionary+Extension.m
@@ -1,0 +1,30 @@
+//
+//  NSExtensions.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/07/16.
+//  Copyright © 2016 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSMutableDictionary+Extension.h"
+
+@implementation NSMutableDictionary (VMMMutableDictionary)
+
++(nullable instancetype)mutableDictionaryWithContentsOfFile:(nonnull NSString*)filePath
+{
+    NSMutableDictionary *dictionary;
+    
+    @try
+    {
+        dictionary = [[NSMutableDictionary alloc] initWithContentsOfFile:filePath];
+    }
+    @catch (NSException *exception)
+    {
+        return nil;
+    }
+    
+    return dictionary;
+}
+
+@end
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableString+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableString+Extension.h
@@ -1,0 +1,24 @@
+//
+//  NSMutableString+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 04/11/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#ifndef NSMutableString_Extension_Class
+#define NSMutableString_Extension_Class
+
+#import <Foundation/Foundation.h>
+
+@interface NSMutableString (VMMMutableString)
+
+-(void)replaceOccurrencesOfString:(nonnull NSString *)target withString:(nonnull NSString *)replacement;
+
+-(void)replaceOccurrencesOfRegex:(nonnull NSString *)target withString:(nonnull NSString *)replacement;
+
+-(nonnull NSMutableString*)trim;
+
+@end
+
+#endif

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableString+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableString+Extension.m
@@ -1,0 +1,84 @@
+//
+//  NSMutableString+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 04/11/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import "NSMutableString+Extension.h"
+#import "NSString+Extension.h"
+
+@implementation NSMutableString (VMMMutableString)
+
+-(void)replaceOccurrencesOfString:(nonnull NSString *)target withString:(nonnull NSString *)replacement
+{
+    [self replaceOccurrencesOfString:target withString:replacement options:0 range:NSMakeRange(0, self.length)];
+}
+
+-(void)replaceOccurrencesOfRegex:(nonnull NSString *)target withString:(nonnull NSString *)replacement
+{
+    NSRange range = NSMakeRange(0, self.length);
+    NSArray<NSString*>* matches = [self componentsMatchingWithRegex:target];
+    for (NSString* match in matches) {
+        [self replaceOccurrencesOfString:match withString:replacement options:0 range:range];
+    }
+}
+
+-(nonnull NSMutableString*)trim
+{
+    // We used to use the method below, but the method in use today is about 2 to 5 times faster
+    
+    //    while ([self hasPrefix:@" "] || [self hasPrefix:@"\n"] || [self hasPrefix:@"\t"])
+    //        [self replaceCharactersInRange:NSMakeRange(0, 1) withString:@""];
+    //    while ([self hasSuffix:@" "] || [self hasSuffix:@"\n"] || [self hasSuffix:@"\t"])
+    //        [self replaceCharactersInRange:NSMakeRange(self.length-1, 1) withString:@""];
+    
+    @autoreleasepool
+    {
+        NSUInteger stringLength = self.length;
+        if (stringLength == 0) return self;
+        
+        NSUInteger indexBegin = 0;
+        unichar invalidCharacters[] = {' ', '\n', '\t', '\0'};
+        int invalidCharactersSize = 4;
+        
+        unichar actualChar;
+        int charIndex;
+        BOOL invalid;
+        while (indexBegin < stringLength) {
+            invalid = false;
+            actualChar = [self characterAtIndex:indexBegin];
+            for (charIndex = 0; charIndex < invalidCharactersSize; charIndex++) {
+                if (invalidCharacters[charIndex] == actualChar) invalid = true;
+            }
+            if (invalid) indexBegin++;
+            else break;
+        }
+        if (indexBegin > 0) {
+            [self replaceCharactersInRange:NSMakeRange(0, indexBegin) withString:@""];
+        }
+        if (indexBegin == stringLength) return self;
+        
+        
+        stringLength = self.length;
+        NSUInteger indexEnd = stringLength - 1;
+        
+        while (indexEnd >= 0) {
+            invalid = false;
+            actualChar = [self characterAtIndex:indexEnd];
+            for (charIndex = 0; charIndex < invalidCharactersSize; charIndex++) {
+                if (invalidCharacters[charIndex] == actualChar) invalid = true;
+            }
+            if (invalid) indexEnd--;
+            else break;
+        }
+        if (stringLength - indexEnd - 1 > 0) {
+            [self replaceCharactersInRange:NSMakeRange(indexEnd + 1, stringLength - indexEnd - 1) withString:@""];
+        }
+    }
+    
+    return self;
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableURLRequest+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableURLRequest+Extension.h
@@ -1,0 +1,20 @@
+//
+//  NSMutableURLRequest+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#ifndef NSMutableURLRequest_Extension_Class
+#define NSMutableURLRequest_Extension_Class
+
+#import <Foundation/Foundation.h>
+
+@interface NSMutableURLRequest (VMMMutableURLRequest)
+
+-(void)ifModifiedSince:(nonnull NSDate*)modificationDate;
+
+@end
+
+#endif

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableURLRequest+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSMutableURLRequest+Extension.m
@@ -1,0 +1,33 @@
+//
+//  NSMutableURLRequest+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSMutableURLRequest+Extension.h"
+
+static NSString* const RFC2822_STANDARD             = @"EEE, dd MMM yyyy HH:mm:ss Z";
+static NSString* const RFC2822_LOCALE               = @"en_US_POSIX";
+static NSString* const IF_MODIFIED_SINCE_HEADER     = @"If-Modified-Since";
+
+@implementation NSMutableURLRequest (VMMMutableURLRequest)
+
+-(void)ifModifiedSince:(nonnull NSDate*)modificationDate
+{
+    NSString *dateString;
+    
+    @autoreleasepool
+    {
+        NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+        dateFormatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:RFC2822_LOCALE];
+        dateFormatter.dateFormat = RFC2822_STANDARD;
+        dateString = [dateFormatter stringFromDate:modificationDate];
+    }
+    
+    [self addValue:dateString forHTTPHeaderField:IF_MODIFIED_SINCE_HEADER];
+}
+
+@end
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSRunningApplication+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSRunningApplication+Extension.h
@@ -1,0 +1,23 @@
+//
+//  NSRunningApplication+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 23/09/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface NSRunningApplication (VMMRunningApplication)
+
+-(nonnull NSArray<NSDictionary*>*)visibleWindows;
+
+-(BOOL)isVisible;
+
+-(nonnull NSArray<NSDictionary*>*)visibleWindowsSizes;
+-(nullable NSDictionary*)windowWithSize:(NSSize)size;
+-(BOOL)hasWindowWithSize:(NSSize)size;
+
+-(void)bringWindowsToFront;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSRunningApplication+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSRunningApplication+Extension.m
@@ -1,0 +1,72 @@
+//
+//  NSRunningApplication+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 23/09/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+//  References:
+//  https://stackoverflow.com/questions/6160727/how-to-obtain-info-of-the-program-from-the-window-list-with-cgwindowlistcopywind
+//  https://superuser.com/questions/902869/how-to-identify-which-process-is-running-which-window-in-mac-os-x
+//
+
+#import "NSRunningApplication+Extension.h"
+
+@implementation NSRunningApplication (VMMRunningApplication)
+
+-(NSArray<NSDictionary*>*)visibleWindows
+{
+    NSMutableArray* appWindows = [[NSMutableArray alloc] init];
+    
+    @autoreleasepool
+    {
+        NSMutableArray* windows = (NSMutableArray *)CFBridgingRelease(CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements, kCGNullWindowID));
+        
+        for (NSDictionary *window in windows)
+        {
+            int ownerPid = [window[@"kCGWindowOwnerPID"] intValue];
+            if (ownerPid == self.processIdentifier)
+            {
+                [appWindows addObject:window];
+            }
+        }
+    }
+    
+    return appWindows;
+}
+
+-(BOOL)isVisible
+{
+    return self.visibleWindows.count > 0;
+}
+
+-(nonnull NSArray<NSDictionary*>*)visibleWindowsSizes
+{
+    return [self.visibleWindows valueForKey:@"kCGWindowBounds"];
+}
+-(nullable NSDictionary*)windowWithSize:(NSSize)size
+{
+    for (NSDictionary *window in self.visibleWindows)
+    {
+        NSDictionary* windowBounds = window[@"kCGWindowBounds"];
+        CGFloat windowHeight = [windowBounds[@"Height"] doubleValue];
+        CGFloat windowWidth  = [windowBounds[@"Width"]  doubleValue];
+        if (ABS(size.width - windowWidth) < 0.1 && ABS(size.height - windowHeight) < 0.1)
+        {
+            return window;
+        }
+    }
+    
+    return nil;
+}
+-(BOOL)hasWindowWithSize:(NSSize)size
+{
+    return [self windowWithSize:size] != nil;
+}
+
+-(void)bringWindowsToFront
+{
+    [self activateWithOptions:(NSApplicationActivateAllWindows | NSApplicationActivateIgnoringOtherApps)];
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSSavePanel+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSSavePanel+Extension.h
@@ -1,0 +1,36 @@
+//
+//  NSSavePanel+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#ifndef NSSavePanel_Extension_Class
+#define NSSavePanel_Extension_Class
+
+#import <Cocoa/Cocoa.h>
+
+@interface NSOpenPanel (VMMOpenPanel)
+
++(void)runThreadSafeModalWithOpenPanel:(void (^)(NSOpenPanel* openPanel))optionsForPanel completionHandler:(void (^) (NSArray<NSURL*>* selectedUrls))completionHandler;
++(void)runMainThreadModalWithOpenPanel:(void (^)(NSOpenPanel* openPanel))optionsForPanel completionHandler:(void (^) (NSArray<NSURL*>* selectedUrls))completionHandler;
++(NSArray<NSURL*>*)runBackgroundThreadModalWithOpenPanel:(void (^)(NSOpenPanel* openPanel))optionsForPanel;
+
+@end
+
+@interface NSSavePanel (VMMSavePanel)
+
+-(NSUInteger)runBackgroundThreadModalWithWindow;
+
++(void)runThreadSafeModalWithSavePanel:(void (^)(NSSavePanel* savePanel))optionsForPanel completionHandler:(void (^) (NSURL* selectedUrl))completionHandler;
++(void)runMainThreadModalWithSavePanel:(void (^)(NSSavePanel* savePanel))optionsForPanel completionHandler:(void (^) (NSURL* selectedUrl))completionHandler;
++(NSURL*)runBackgroundThreadModalWithSavePanel:(void (^)(NSSavePanel* savePanel))optionsForPanel;
+
+-(void)setInitialDirectory:(NSString*)path;
+
+-(void)setWindowTitle:(NSString*)string;
+
+@end
+
+#endif

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSSavePanel+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSSavePanel+Extension.m
@@ -1,0 +1,217 @@
+//
+//  NSSavePanel+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSSavePanel+Extension.h"
+
+#import "NSThread+Extension.h"
+
+#import "VMMComputerInformation.h"
+
+#import "VMMModals.h"
+
+@implementation NSOpenPanel (VMMOpenPanel)
+
++(void)runThreadSafeModalWithOpenPanel:(void (^)(NSOpenPanel* openPanel))optionsForPanel completionHandler:(void (^) (NSArray<NSURL*>* selectedUrls))completionHandler
+{
+    if ([NSThread isMainThread])
+    {
+        [self runMainThreadModalWithOpenPanel:optionsForPanel completionHandler:completionHandler];
+    }
+    else
+    {
+        NSArray* selectedUrls = [self runBackgroundThreadModalWithOpenPanel:optionsForPanel];
+        completionHandler(selectedUrls);
+    }
+}
++(void)runMainThreadModalWithOpenPanel:(void (^)(NSOpenPanel* openPanel))optionsForPanel completionHandler:(void (^) (NSArray<NSURL*>* selectedUrls))completionHandler
+{
+    NSOpenPanel* openPanel = [NSOpenPanel openPanel];
+    optionsForPanel(openPanel);
+    
+    NSWindow* window = [VMMModals modalsWindow];
+    if (window != nil)
+    {
+        [openPanel beginSheetModalForWindow:window completionHandler:^(NSModalResponse result)
+        {
+            [openPanel orderOut:nil];
+             
+            if (result == NSOKButton)
+            {
+                completionHandler([openPanel URLs]);
+            }
+        }];
+    }
+    else
+    {
+        if ([openPanel runModal] == NSOKButton)
+        {
+            completionHandler([openPanel URLs]);
+        }
+    }
+}
++(NSArray<NSURL*>*)runBackgroundThreadModalWithOpenPanel:(void (^)(NSOpenPanel* openPanel))optionsForPanel
+{
+    __block NSArray<NSURL*>* urlsList;
+    
+    NSCondition* lock = [[NSCondition alloc] init];
+    __block NSUInteger value;
+    
+    [NSThread dispatchBlockInMainQueue:^
+    {
+        NSOpenPanel* openPanel = [NSOpenPanel openPanel];
+        optionsForPanel(openPanel);
+        
+        [NSThread dispatchQueueWithName:"open-panel-background-thread" priority:DISPATCH_QUEUE_PRIORITY_DEFAULT concurrent:NO withBlock:^
+        {
+            value = [openPanel runBackgroundThreadModalWithWindow];
+            if (value == NSOKButton)
+            {
+                urlsList = [openPanel URLs];
+            }
+             
+            [lock signal];
+        }];
+    }];
+    
+    [lock lock];
+    [lock wait];
+    [lock unlock];
+    
+    return urlsList;
+}
+
+@end
+
+@implementation NSSavePanel (VMMSavePanel)
+
+-(NSUInteger)runBackgroundThreadModalWithWindow
+{
+    NSWindow* window = [VMMModals modalsWindow];
+    
+    __block NSUInteger value;
+    NSCondition* lock = [[NSCondition alloc] init];
+    
+    [NSThread dispatchBlockInMainQueue:^
+    {
+        if (window != nil)
+        {
+            [self beginSheetModalForWindow:window completionHandler:^(NSModalResponse result)
+            {
+                [self orderOut:nil];
+                value = result;
+                [lock signal];
+            }];
+        }
+        else
+        {
+            value = [self runModal];
+            [lock signal];
+        }
+    }];
+    
+    [lock lock];
+    [lock wait];
+    [lock unlock];
+    
+    return value;
+}
+
++(void)runThreadSafeModalWithSavePanel:(void (^)(NSSavePanel* savePanel))optionsForPanel completionHandler:(void (^) (NSURL* selectedUrl))completionHandler
+{
+    if ([NSThread isMainThread])
+    {
+        [self runMainThreadModalWithSavePanel:optionsForPanel completionHandler:completionHandler];
+    }
+    else
+    {
+        NSURL* selectedUrl = [self runBackgroundThreadModalWithSavePanel:optionsForPanel];
+        completionHandler(selectedUrl);
+    }
+}
++(void)runMainThreadModalWithSavePanel:(void (^)(NSSavePanel* savePanel))optionsForPanel completionHandler:(void (^) (NSURL* selectedUrl))completionHandler
+{
+    NSSavePanel* savePanel = [NSSavePanel savePanel];
+    optionsForPanel(savePanel);
+    
+    NSWindow* window = [VMMModals modalsWindow];
+    if (window != nil)
+    {
+        [savePanel beginSheetModalForWindow:window completionHandler:^(NSModalResponse result)
+        {
+            [savePanel orderOut:nil];
+            
+            if (result == NSOKButton)
+            {
+                completionHandler([savePanel URL]);
+            }
+        }];
+    }
+    else
+    {
+        if ([savePanel runModal] == NSOKButton)
+        {
+            completionHandler([savePanel URL]);
+        }
+    }
+}
++(NSURL*)runBackgroundThreadModalWithSavePanel:(void (^)(NSSavePanel* savePanel))optionsForPanel
+{
+    __block NSURL* url;
+    
+    NSCondition* lock = [[NSCondition alloc] init];
+    __block NSUInteger value;
+    
+    [NSThread dispatchBlockInMainQueue:^
+    {
+        NSSavePanel* savePanel = [NSSavePanel savePanel];
+        optionsForPanel(savePanel);
+        
+        [NSThread dispatchQueueWithName:"save-panel-background-thread" priority:DISPATCH_QUEUE_PRIORITY_DEFAULT concurrent:NO withBlock:^
+        {
+            value = [savePanel runBackgroundThreadModalWithWindow];
+            if (value == NSOKButton)
+            {
+                url = [savePanel URL];
+            }
+            
+            [lock signal];
+        }];
+    }];
+    
+    [lock lock];
+    [lock wait];
+    [lock unlock];
+    
+    return url;
+}
+
+-(void)setInitialDirectory:(NSString*)path
+{
+    [self setDirectoryURL:[NSURL fileURLWithPath:path isDirectory:YES]];
+}
+
+-(void)setWindowTitle:(NSString*)string
+{
+    if ([self isKindOfClass:[NSOpenPanel class]])
+    {
+        if (IS_SYSTEM_MAC_OS_10_11_OR_SUPERIOR)
+        {
+            [self setMessage:string];
+        }
+        else
+        {
+            [self setTitle:string];
+        }
+    }
+    else
+    {
+        [self setTitle:string];
+    }
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSScreen+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSScreen+Extension.h
@@ -1,0 +1,15 @@
+//
+//  NSScreen+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 04/10/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface NSScreen (VMMScreen)
+
+-(CGFloat)retinaScale;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSScreen+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSScreen+Extension.m
@@ -1,0 +1,18 @@
+//
+//  NSScreen+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 04/10/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import "NSScreen+Extension.h"
+
+@implementation NSScreen (VMMScreen)
+
+-(CGFloat)retinaScale
+{
+    return [self respondsToSelector:@selector(backingScaleFactor)] ? self.backingScaleFactor : self.userSpaceScaleFactor;
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSString+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSString+Extension.h
@@ -1,0 +1,59 @@
+//
+//  NSString+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#ifndef NSString_Extension_Class
+#define NSString_Extension_Class
+
+#import <Foundation/Foundation.h>
+
+@interface NSString (VMMString)
+
++(nonnull  NSString*)stringWithCFTypeIDDescription:(CFTypeRef _Nonnull)cf_type;
++(nullable NSString*)stringWithCFString:(CFStringRef _Nonnull)cf_string;
++(nonnull  NSString*)stringWithCFNumber:(CFNumberRef _Nonnull)cf_number ofType:(CFNumberType)number_type;
++(nullable NSString*)stringWithCFType:(CFTypeRef _Nonnull)cf_type;
+
+-(NSRange)rangeOfUnescapedChar:(char)character;
+-(NSRange)rangeOfUnescapedChar:(char)character range:(NSRange)rangeOfReceiverToSearch;
+
+-(BOOL)contains:(nonnull NSString*)string;
+-(BOOL)matchesWithSearchTerms:(nonnull NSArray*)searchTerms;
+-(nonnull NSArray<NSString*>*)searchTermsWithString;
+
+-(BOOL)matchesWithRegex:(nonnull NSString*)regexString;
+-(nonnull NSArray<NSString*>*)componentsMatchingWithRegex:(nonnull NSString*)regexString;
+
++(nonnull NSString*)humanReadableSizeForBytes:(long long int)bytes withDecimalMeasureSystem:(BOOL)measure;
+
+-(nonnull NSString*)hexadecimalUTF8String;
++(nullable NSString*)stringWithHexadecimalUTF8String:(nonnull NSString*)string;
+
++(nonnull NSString*)stringByRemovingEvenCharsFromString:(nonnull NSString*)text;
+-(nonnull NSString*)stringToWebStructure;
+
+-(NSRange)rangeAfterString:(nullable NSString*)before andBeforeString:(nullable NSString*)after;
+-(nullable NSString*)getFragmentAfter:(nullable NSString*)before andBefore:(nullable NSString*)after;
+
+-(nullable NSNumber*)initialIntegerValue;
+
++(nullable NSString*)stringWithContentsOfFile:(nonnull NSString*)file;
++(nullable NSString*)stringWithContentsOfFile:(nonnull NSString*)file encoding:(NSStringEncoding)enc;
++(void)stringWithContentsOfURL:(nonnull NSURL *)url encoding:(NSStringEncoding)enc timeoutInterval:(long long int)timeoutInterval withCompletionHandler:(void (^_Nullable)(NSUInteger statusCode, NSString* _Nullable string, NSError* _Nullable error))completion;
+
+-(BOOL)writeToFile:(nonnull NSString*)path atomically:(BOOL)useAuxiliaryFile encoding:(NSStringEncoding)enc;
+
+-(nonnull NSData*)dataWithBase64Encoding;
+
+-(BOOL)isAValidURL;
+
+-(NSString*)stringByReplacingCharactersInSet:(NSCharacterSet *)characterset withString:(NSString *)string;
+-(NSString*)stringByRemovingCharactersInSet:(NSCharacterSet *)characterset;
+
+@end
+
+#endif

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSString+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSString+Extension.m
@@ -1,0 +1,601 @@
+//
+//  NSString+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSString+Extension.h"
+
+#import "NSData+Extension.h"
+#import "NSTask+Extension.h"
+#import "VMMAlert.h"
+#import "NSFileManager+Extension.h"
+#import "NSMutableString+Extension.h"
+
+#import "VMMComputerInformation.h"
+#import "VMMLocalizationUtility.h"
+#import "VMMUUID.h"
+
+@implementation NSString (VMMString)
+
++(nonnull NSString*)stringWithCFTypeIDDescription:(CFTypeRef _Nonnull)cf_type {
+    CFTypeID type_id = (CFTypeID) CFGetTypeID(cf_type);
+    CFStringRef typeIdDescription = CFCopyTypeIDDescription(type_id);
+    NSString* string = [self stringWithCFString:typeIdDescription];
+    CFRelease(typeIdDescription);
+    return [NSString stringWithFormat:@"<%@>",string];
+}
++(nullable NSString*)stringWithCFString:(CFStringRef _Nonnull)cf_string {
+    char * buffer;
+    CFIndex len = CFStringGetLength(cf_string);
+    buffer = (char *) malloc(sizeof(char) * len + 1);
+    CFStringGetCString(cf_string, buffer, len + 1,
+                       CFStringGetSystemEncoding());
+    NSString* string = [NSString stringWithUTF8String:buffer];
+    free(buffer);
+    return string;
+}
++(nonnull NSString*)stringWithCFNumber:(CFNumberRef _Nonnull)cf_number ofType:(CFNumberType)number_type {
+    int number; 
+    CFNumberGetValue(cf_number, number_type, &number);
+    return [NSString stringWithFormat:@"%d",number];
+}
++(nullable NSString*)stringWithCFType:(CFTypeRef _Nonnull)cf_type {
+    CFTypeID type_id;
+    
+    type_id = (CFTypeID) CFGetTypeID(cf_type);
+    if (type_id == CFStringGetTypeID())
+    {
+        return [self stringWithCFString:cf_type];
+    }
+    else if (type_id == CFNumberGetTypeID())
+    {
+        return [self stringWithCFNumber:cf_type ofType:kCFNumberIntType];
+    }
+    else if (type_id == CFDateGetTypeID())
+    {
+        // TODO: Not tested
+        NSDate* date = (__bridge NSDate*)cf_type;
+        return [date descriptionWithLocale:[NSLocale currentLocale]];
+    }
+    
+    // TODO: The types below are still unsupported:
+    //{CFArrayGetTypeID(),"CFArray"},
+    //{CFBooleanGetTypeID(),"CFBoolean"},
+    //{CFDataGetTypeID(),"CFData"},
+    //{CFDictionaryGetTypeID(),"CFDictionary"},
+    
+    return nil;
+}
+
+-(NSRange)rangeOfUnescapedChar:(char)character
+{
+    return [self rangeOfUnescapedChar:character range:NSMakeRange(0, self.length)];
+}
+-(NSRange)rangeOfUnescapedChar:(char)character range:(NSRange)rangeOfReceiverToSearch
+{
+    NSString* characterString = [NSString stringWithFormat:@"%c",character];
+    
+    NSUInteger index = rangeOfReceiverToSearch.location;
+    NSRange range = [self rangeOfString:characterString options:NSCaseInsensitiveSearch
+                                  range:NSMakeRange(index, rangeOfReceiverToSearch.length - index)];
+    while (range.location != NSNotFound) {
+        BOOL isEscaped = false;
+        NSUInteger escapeIndex = range.location-1;
+        while (escapeIndex != -1 && [self characterAtIndex:escapeIndex] == '\\') {
+            escapeIndex--;
+            isEscaped = !isEscaped;
+        }
+        if (!isEscaped) {
+            return range; // SUCCESS (found)
+        }
+        if (rangeOfReceiverToSearch.length == range.location + 1) return range; // FAILURE (last character reached)
+        
+        index = range.location + 1;
+        range = [self rangeOfString:characterString options:NSCaseInsensitiveSearch
+                              range:NSMakeRange(index, rangeOfReceiverToSearch.length - index)];
+    }
+    
+    return range; // FAILURE (don't exist)
+}
+
+-(BOOL)contains:(nonnull NSString*)string
+{
+    return [self rangeOfString:string].location != NSNotFound;
+}
+-(BOOL)containsWord:(NSString*)word
+{
+    BOOL result;
+    
+    @autoreleasepool
+    {
+        NSArray* words = [self.lowercaseString componentsSeparatedByString:@" "];
+        result = [words containsObject:word];
+    }
+    
+    return result;
+}
+-(BOOL)containsOneOfSynonyms:(NSArray*)words
+{
+    for (NSString* word in words)
+    {
+        if ([self containsWord:word])
+        {
+            return YES;
+        }
+    }
+    
+    return NO;
+}
+-(BOOL)containsAbbreviation:(NSString*)string
+{
+    @autoreleasepool
+    {
+        NSString* abbreviation = string.lowercaseString;
+        
+        NSMutableArray* words = [[self.lowercaseString componentsSeparatedByString:@" "] mutableCopy];
+        [words removeObject:@""];
+        
+        if (words.count < abbreviation.length)
+        {
+            return false;
+        }
+        
+        int lettersSkipped;
+        BOOL patternMatches = NO;
+        BOOL letterMatches = NO;
+        char letter;
+        
+        for (int wordIndex = 0; wordIndex <= words.count - abbreviation.length; wordIndex++)
+        {
+            letter = [abbreviation characterAtIndex:0];
+            letterMatches = [words[wordIndex] characterAtIndex:0] == letter;
+            
+            if (letterMatches)
+            {
+                patternMatches = NO;
+                lettersSkipped = 0;
+                
+                for (int letterIndex = 1; letterIndex < abbreviation.length; letterIndex++)
+                {
+                    letter = [abbreviation characterAtIndex:letterIndex];
+                    letterMatches = [words[wordIndex+letterIndex+lettersSkipped] characterAtIndex:0] == letter;
+                    
+                    if (letterMatches && letterIndex == abbreviation.length - 1) patternMatches = YES;
+                    
+                    if (words.count == wordIndex + letterIndex + lettersSkipped + 1)
+                    {
+                        break;
+                    }
+                    
+                    if (!letterMatches)
+                    {
+                        lettersSkipped++;
+                        letterIndex--;
+                    }
+                }
+                
+                if (patternMatches) break;
+            }
+            
+            if (patternMatches) break;
+        }
+        
+        return patternMatches;
+    }
+}
+-(BOOL)matchesWithSearchTerms:(nonnull NSArray*)searchTerms
+{
+    @autoreleasepool
+    {
+        NSCharacterSet* unitingSetItem    = [NSCharacterSet characterSetWithCharactersInString:@"'."];
+        NSCharacterSet* separatingSetItem = [NSCharacterSet characterSetWithCharactersInString:@"&"];
+        
+        NSString* string = [self.lowercaseString stringByReplacingCharactersInSet:unitingSetItem withString:@" "];
+        string = [[string componentsSeparatedByCharactersInSet:separatingSetItem] componentsJoinedByString:@" "];
+        
+        for (NSString* term in searchTerms)
+        {
+            if (![string contains:term] && ![string containsAbbreviation:term])
+            {
+                NSArray* synonymsPairs = @[@[@"&",@"and"],@[@"vs",@"versus"],
+                                           @[@"i",    @"1"],@[@"ii",   @"2"],@[@"iii",   @"3"],@[@"iv",  @"4"],@[@"v",   @"5"],
+                                           @[@"vi",   @"6"],@[@"vii",  @"7"],@[@"viii",  @"8"],@[@"ix",  @"9"],@[@"x",  @"10"],
+                                           @[@"xi",  @"11"],@[@"xii", @"12"],@[@"xiii", @"13"],@[@"xiv",@"14"],@[@"xv", @"15"],
+                                           @[@"xvi", @"16"],@[@"xvii",@"17"],@[@"xviii",@"18"],@[@"xix",@"19"]];
+                
+                BOOL hadASynonym = NO;
+                
+                for (NSArray* pair in synonymsPairs)
+                {
+                    if ([pair containsObject:term])
+                    {
+                        hadASynonym = YES;
+                        if (![string containsOneOfSynonyms:pair]) return NO;
+                    }
+                }
+                
+                if (!hadASynonym) return NO;
+            }
+        }
+    }
+    
+    return YES;
+}
+-(nonnull NSArray<NSString*>*)searchTermsWithString
+{
+    NSArray* searchTerms;
+    
+    @autoreleasepool
+    {
+        NSCharacterSet* separatingSetSearch = [NSCharacterSet characterSetWithCharactersInString:@" :-*?!.,'+&()[]{}"];
+        NSArray* mustIgnoreWords = @[@""];
+        NSArray* mayIgnoreWords = @[@"a",@"of",@"the",@"in",@"to"];
+        
+        searchTerms = [self.lowercaseString componentsSeparatedByCharactersInSet:separatingSetSearch];
+        
+        NSMutableArray* clearSearchTerms = [searchTerms mutableCopy];
+        [clearSearchTerms removeObjectsInArray:mustIgnoreWords];
+        
+        NSMutableArray* filteredSearchTerms = [clearSearchTerms mutableCopy];
+        [filteredSearchTerms removeObjectsInArray:mayIgnoreWords];
+        
+        if (filteredSearchTerms.count == 0)
+        {
+            searchTerms = clearSearchTerms;
+        }
+        else
+        {
+            searchTerms = filteredSearchTerms;
+        }
+    }
+    
+    return searchTerms;
+}
+
+-(BOOL)matchesWithRegex:(nonnull NSString*)regexString
+{
+    BOOL result;
+    
+    @autoreleasepool
+    {
+        NSPredicate* regex = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", regexString];
+        result = [regex evaluateWithObject:self];
+    }
+    
+    return result;
+}
+-(nonnull NSArray<NSString*>*)componentsMatchingWithRegex:(nonnull NSString*)regexString
+{
+    NSMutableArray* matches;
+    
+    if (IsClassNSRegularExpressionAvailable == false)
+    {
+        // TODO: Find a different way to replace NSRegularExpression... there must be a better way
+        
+        @autoreleasepool
+        {
+            NSString* uuid = VMMUUIDCreate();
+            NSString* pyFileName  = [NSString stringWithFormat:@"pythonRegex%@.py",uuid];
+            NSString* datFileName = [NSString stringWithFormat:@"pythonFile%@.dat",uuid];
+            
+            NSString* pythonScriptPath = [NSString stringWithFormat:@"%@%@",NSTemporaryDirectory(),pyFileName ];
+            NSString* stringFilePath   = [NSString stringWithFormat:@"%@%@",NSTemporaryDirectory(),datFileName];
+            
+            NSArray* pythonScriptContentsArray = @[@"import re",
+                                                   @"import os",
+                                                   @"dir_path = os.path.dirname(os.path.abspath(__file__))",
+                                                   [NSString stringWithFormat:@"text_file = open(dir_path + \"/%@\", \"r\")",datFileName],
+                                                   @"text = text_file.read()",
+                                                   [NSString stringWithFormat:@"regex = re.compile(r\"(%@)\")",regexString],
+                                                   @"matches = regex.finditer(text)",
+                                                   @"for match in matches:",
+                                                   @"    print match.group()"];
+            NSString* pythonScriptContents = [pythonScriptContentsArray componentsJoinedByString:@"\n"];
+            
+            [self                 writeToFile:stringFilePath   atomically:YES encoding:NSASCIIStringEncoding];
+            [pythonScriptContents writeToFile:pythonScriptPath atomically:YES encoding:NSASCIIStringEncoding];
+            
+            NSString* output = [NSTask runCommand:@[@"python", pythonScriptPath]];
+            matches = [[output componentsSeparatedByString:@"\n"] mutableCopy];
+            [matches removeObject:@""];
+        }
+        
+        return matches;
+    }
+    
+    @autoreleasepool
+    {
+        NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:regexString options:0 error:NULL];
+        NSArray* rangeArray = [regex matchesInString:self options:0 range:NSMakeRange(0, self.length)];
+        
+        matches = [[NSMutableArray alloc] init];
+        for (NSTextCheckingResult *match in rangeArray)
+        {
+            [matches addObject:[self substringWithRange:match.range]];
+        }
+    }
+        
+    return matches;
+}
+
++(nonnull NSString*)humanReadableSizeForBytes:(long long int)bytes withDecimalMeasureSystem:(BOOL)measure
+{
+    NSString* result;
+    
+    @autoreleasepool
+    {
+        int degree = 0;
+        int minorBytes = 0;
+        int divisor = measure ? 1000 : 1024;
+        
+        while (bytes/divisor && degree < 8)
+        {
+            minorBytes=bytes%divisor;
+            bytes/=divisor;
+            degree++;
+        }
+        
+        switch (degree)
+        {
+            case 0:  result = @"b";  break;
+            case 1:  result = @"Kb"; break;
+            case 2:  result = @"Mb"; break;
+            case 3:  result = @"Gb"; break;
+            case 4:  result = @"Tb"; break;
+            case 5:  result = @"Pb"; break;
+            case 6:  result = @"Eb"; break;
+            case 7:  result = @"Zb"; break;
+            default: result = @"Yb"; break;
+        }
+        
+        minorBytes = ((minorBytes*1000)/divisor)/100;
+        if (minorBytes > 0) result = [NSString stringWithFormat:@".%d%@",minorBytes,result];
+        
+        result = [NSString stringWithFormat:@"%lld%@",bytes,result];
+    }
+    
+    return result;
+}
+
+-(nonnull NSString*)hexadecimalUTF8String
+{
+    NSString* hexStr;
+    
+    @autoreleasepool
+    {
+        const char* cString = [self cStringUsingEncoding:NSUTF8StringEncoding];
+        hexStr = [NSString stringWithFormat:@"%@", [NSData dataWithBytes:cString length:strlen(cString)]];
+        hexStr = [hexStr stringByRemovingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"<> "]];
+    }
+    
+    return hexStr;
+}
++(nullable NSString*)stringWithHexadecimalUTF8String:(nonnull NSString*)string
+{
+    NSMutableString* newString;
+    
+    @autoreleasepool
+    {
+        newString = [[NSMutableString alloc] init];
+        NSScanner* scanner = [[NSScanner alloc] initWithString:string];
+        unsigned value;
+        while ([scanner scanHexInt:&value])
+        {
+            if (value==0) [newString appendString:@"\0"];
+            else [newString appendFormat:@"%c",(char)(value & 0xFF)];
+        }
+    }
+    
+    return newString;
+}
+
++(nonnull NSString*)stringByRemovingEvenCharsFromString:(nonnull NSString*)text
+{
+    NSMutableString* text2;
+    
+    @autoreleasepool
+    {
+        text2 = [NSMutableString stringWithString:@""];
+        
+        for (int x = 0; x < text.length; x = x+2)
+        {
+            [text2 appendString:[text substringWithRange:NSMakeRange(x,1)]];
+        }
+    }
+    
+    return text2;
+}
+-(nonnull NSString*)stringToWebStructure
+{
+    NSString* webString;
+    
+    @autoreleasepool
+    {
+        webString = [self stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+        
+        webString = [webString stringByReplacingOccurrencesOfString:@"&" withString:@"%26"];
+        webString = [webString stringByReplacingOccurrencesOfString:@"+" withString:@"%2B"];
+        webString = [webString stringByReplacingOccurrencesOfString:@"/" withString:@"%2F"];
+        webString = [webString stringByReplacingOccurrencesOfString:@";" withString:@"%3B"];
+        webString = [webString stringByReplacingOccurrencesOfString:@"=" withString:@"%3D"];
+        webString = [webString stringByReplacingOccurrencesOfString:@"?" withString:@"%3F"];
+    }
+    
+    return webString;
+}
+
+-(NSRange)rangeAfterString:(nullable NSString*)before andBeforeString:(nullable NSString*)after
+{
+    NSRange result;
+    
+    @autoreleasepool
+    {
+        NSRange beforeRange = before ? [self rangeOfString:before] : NSMakeRange(0, 0);
+        
+        if (beforeRange.location == NSNotFound)
+        {
+            return NSMakeRange(NSNotFound, 0);
+        }
+        
+        CGFloat afterBeforeRangeStart = beforeRange.location + beforeRange.length;
+        NSRange afterBeforeRange = NSMakeRange(afterBeforeRangeStart, self.length - afterBeforeRangeStart);
+        NSRange afterRange = after ? [self rangeOfString:after options:0 range:afterBeforeRange] : NSMakeRange(NSNotFound, 0);
+        
+        if (afterRange.location == NSNotFound)
+        {
+            return afterBeforeRange;
+        }
+        
+        result = NSMakeRange(afterBeforeRangeStart, afterRange.location - afterBeforeRangeStart);
+    }
+    
+    return result;
+}
+-(nullable NSString*)getFragmentAfter:(nullable NSString*)before andBefore:(nullable NSString*)after
+{
+    NSRange range = [self rangeAfterString:before andBeforeString:after];
+    if (range.location == NSNotFound) return nil;
+    return [self substringWithRange:range];
+}
+
+-(nullable NSNumber*)initialIntegerValue
+{
+    NSNumber* numberValue;
+    
+    @autoreleasepool
+    {
+        NSMutableString* originalString = [self mutableCopy];
+        NSMutableString* newString = [NSMutableString stringWithString:@""];
+        NSRange firstCharRange = NSMakeRange(0, 1);
+        
+        while (originalString.length > 0 && [originalString characterAtIndex:0] >= '0' && [originalString characterAtIndex:0] <= '9')
+        {
+            [newString appendString:[originalString substringWithRange:firstCharRange]];
+            [originalString deleteCharactersInRange:firstCharRange];
+        }
+        
+        if (newString.length > 0) numberValue = [[NSNumber alloc] initWithInt:newString.intValue];
+    }
+    
+    return numberValue;
+}
+
++(nullable NSString*)stringWithContentsOfFile:(nonnull NSString*)file
+{
+    if (![[NSFileManager defaultManager] regularFileExistsAtPath:file]) return nil;
+    
+    @autoreleasepool
+    {
+        for (NSNumber* encoding in @[@(NSUTF8StringEncoding),@(NSASCIIStringEncoding),@(NSISOLatin1StringEncoding)])
+        {
+            NSError* error;
+            NSString* string = [self stringWithContentsOfFile:file encoding:encoding.unsignedIntegerValue error:&error];
+            
+            if (error == nil && string != nil)
+            {
+                return string;
+            }
+        }
+    }
+    
+    return nil;
+}
++(nullable NSString*)stringWithContentsOfFile:(nonnull NSString*)file encoding:(NSStringEncoding)enc
+{
+    if (![[NSFileManager defaultManager] regularFileExistsAtPath:file]) return nil;
+    
+    NSError* error;
+    NSString* string = [self stringWithContentsOfFile:file encoding:enc error:&error];
+    
+    if (error != nil)
+    {
+        [VMMAlert showAlertOfType:VMMAlertTypeError withMessage:[NSString stringWithFormat:VMMLocalizedString(@"Error while reading file text: %@"), error.localizedDescription]];
+    }
+    
+    return string;
+}
++(void)stringWithContentsOfURL:(nonnull NSURL *)url encoding:(NSStringEncoding)enc timeoutInterval:(long long int)timeoutInterval withCompletionHandler:(void (^)(NSUInteger statusCode, NSString* string, NSError* error))completion
+{
+    @autoreleasepool
+    {
+        [NSData dataWithContentsOfURL:url timeoutInterval:timeoutInterval withCompletionHandler:
+         ^(NSUInteger statusCode, NSData *data, NSError *error)
+        {
+            NSString* stringValue = (data != nil) ? [[NSString alloc] initWithData:data encoding:enc] : nil;
+
+            if (completion != nil) {
+                completion(statusCode, stringValue, error);
+            }
+        }];
+    }
+}
+
+-(BOOL)writeToFile:(nonnull NSString*)path atomically:(BOOL)useAuxiliaryFile encoding:(NSStringEncoding)enc
+{
+    if (![[NSFileManager defaultManager] regularFileExistsAtPath:path])
+    {
+        [[NSFileManager defaultManager] createEmptyFileAtPath:path];
+    }
+    
+    NSError* error;
+    BOOL created = [self writeToFile:path atomically:useAuxiliaryFile encoding:enc error:&error];
+    
+    if (error != nil)
+    {
+        [VMMAlert showAlertOfType:VMMAlertTypeError withMessage:[NSString stringWithFormat:VMMLocalizedString(@"Error while writting file: %@"), error.localizedDescription]];
+    }
+    
+    return created;
+}
+
+-(nonnull NSData*)dataWithBase64Encoding
+{
+    if (!IS_SYSTEM_MAC_OS_10_9_OR_SUPERIOR)
+    {
+        return [[NSData alloc] initWithBase64Encoding:self];
+    }
+    
+    return [[NSData alloc] initWithBase64EncodedString:self options:0];
+}
+
+-(BOOL)isAValidURL
+{
+    BOOL isValid = true;
+    
+    @autoreleasepool
+    {
+        if (![self hasPrefix:@"http://"] && ![self hasPrefix:@"https://"] && ![self hasPrefix:@"ftp://"])
+        {
+            isValid = false;
+        }
+        
+        if (isValid)
+        {
+            NSURL *candidateURL = [NSURL URLWithString:self];
+            isValid = candidateURL && candidateURL.scheme && candidateURL.host;
+        }
+    }
+    
+    return isValid;
+}
+
+-(NSString*)stringByReplacingCharactersInSet:(NSCharacterSet *)characterset withString:(NSString *)string
+{
+    NSString *result = self;
+    NSRange range = [result rangeOfCharacterFromSet:characterset];
+    
+    while (range.location != NSNotFound) {
+        result = [result stringByReplacingCharactersInRange:range withString:string];
+        range = [result rangeOfCharacterFromSet:characterset];
+    }
+    return result;
+}
+-(NSString*)stringByRemovingCharactersInSet:(NSCharacterSet *)characterset
+{
+    return [self stringByReplacingCharactersInSet:characterset withString:@""];
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSTask+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSTask+Extension.h
@@ -1,0 +1,39 @@
+//
+//  NSTask+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#ifndef NSTask_Extension_Class
+#define NSTask_Extension_Class
+
+#import <Foundation/Foundation.h>
+
+@interface NSTask (VMMTask)
+
++(NSArray*)componentsFromFlagsString:(NSString*)initialFlags;
+
++(NSString*)runCommand:(NSArray<NSString*>*)programAndFlags;
++(NSString*)runCommand:(NSArray<NSString*>*)programAndFlags atRunPath:(NSString*)path;
++(NSString*)runCommand:(NSArray<NSString*>*)programAndFlags atRunPath:(NSString*)path andWait:(BOOL)shouldWait;
+
++(void)runAsynchronousCommand:(NSArray<NSString*>*)programAndFlags;
+
++(NSString*)runProgram:(NSString*)program;
++(NSString*)runProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags;
++(NSString*)runProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags outputEncoding:(NSStringEncoding)encoding;
++(NSString*)runProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags atRunPath:(NSString*)path andWaiting:(BOOL)wait;
++(NSString*)runProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags withEnvironment:(NSDictionary*)env;
++(NSString*)runProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags atRunPath:(NSString*)path withEnvironment:(NSDictionary*)env;
++(NSString*)runProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags waitingForTimeInterval:(unsigned int)timeout;
+
++(void)runAsynchronousProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags withEnvironment:(NSDictionary*)env;
++(void)runAsynchronousProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags atRunPath:(NSString*)path withEnvironment:(NSDictionary*)env;
+
++(NSString*)runProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags atRunPath:(NSString*)path withEnvironment:(NSDictionary*)env andWaiting:(BOOL)wait forTimeInterval:(unsigned int)timeout outputEncoding:(NSStringEncoding)encoding;
+
+@end
+
+#endif

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSTask+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSTask+Extension.m
@@ -1,0 +1,284 @@
+//
+//  NSTask+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSTask+Extension.h"
+
+#import "VMMAlert.h"
+#import "NSMutableString+Extension.h"
+#import "NSThread+Extension.h"
+#import "NSFileManager+Extension.h"
+
+#import "VMMLogUtility.h"
+#import "VMMLocalizationUtility.h"
+
+@implementation NSTask (VMMTask)
+
+static NSMutableDictionary* binaryPaths;
+
++(NSArray*)componentsFromFlagsString:(NSString*)initialFlags
+{
+    NSMutableArray* flagComponents = [[NSMutableArray alloc] init];
+    
+    NSString* flags = [[initialFlags mutableCopy] trim];
+    NSRange quoteRange = [flags rangeOfUnescapedChar:'"'];
+    NSRange spaceRange = [flags rangeOfString:@" "];
+    while (quoteRange.location != NSNotFound || spaceRange.location != NSNotFound) {
+        
+        if (quoteRange.location == flags.length - 1) {
+            return nil; // Invalid string
+        }
+        
+        if (quoteRange.location != NSNotFound && (spaceRange.location == NSNotFound || spaceRange.location > quoteRange.location)) {
+            NSRange nextQuoteRange = [flags rangeOfUnescapedChar:'"'
+                                            range:NSMakeRange(quoteRange.location + 1, flags.length - (quoteRange.location + 1))];
+            if (nextQuoteRange.location == NSNotFound) {
+                return nil; // Invalid string
+            }
+            NSString* comp = [flags substringWithRange:NSMakeRange(quoteRange.location + 1,
+                                                                   nextQuoteRange.location - (quoteRange.location + 1))];
+            [flagComponents addObject:comp];
+            flags = [[[flags substringFromIndex:nextQuoteRange.location+1] mutableCopy] trim];
+        }
+        else if (spaceRange.location != NSNotFound) {
+            NSString* comp = [flags substringToIndex:spaceRange.location];
+            [flagComponents addObject:comp];
+            flags = [[[flags substringFromIndex:spaceRange.location] mutableCopy] trim];
+        }
+        
+        quoteRange = [flags rangeOfUnescapedChar:'"'];
+        spaceRange = [flags rangeOfString:@" "];
+    }
+    
+    if (flags.length > 0) {
+        [flagComponents addObject:flags];
+    }
+    
+    return flagComponents;
+}
+
++(NSString*)runCommand:(NSArray<NSString*>*)programAndFlags
+{
+    return [self runCommand:programAndFlags atRunPath:nil];
+}
++(NSString*)runCommand:(NSArray<NSString*>*)programAndFlags atRunPath:(NSString*)path
+{
+    return [self runCommand:programAndFlags atRunPath:path andWait:YES];
+}
++(NSString*)runCommand:(NSArray<NSString*>*)programAndFlags atRunPath:(NSString*)path andWait:(BOOL)shouldWait
+{
+    NSArray* flags = [programAndFlags objectsAtIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(1, programAndFlags.count - 1)]];
+    return [self runProgram:programAndFlags.firstObject withFlags:flags atRunPath:path andWaiting:shouldWait];
+}
+
++(void)runAsynchronousCommand:(NSArray<NSString*>*)programAndFlags
+{
+    [self runCommand:programAndFlags atRunPath:nil andWait:NO];
+}
+
++(NSString*)runProgram:(NSString*)program
+{
+    return [self runProgram:program withFlags:nil atRunPath:nil andWaiting:YES];
+}
++(NSString*)runProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags
+{
+    return [self runProgram:program withFlags:flags atRunPath:nil andWaiting:YES];
+}
++(NSString*)runProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags outputEncoding:(NSStringEncoding)encoding
+{
+    return [self runProgram:program withFlags:flags atRunPath:nil withEnvironment:nil
+                 andWaiting:YES forTimeInterval:0 outputEncoding:encoding];
+}
++(NSString*)runProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags atRunPath:(NSString*)path andWaiting:(BOOL)wait
+{
+    return [self runProgram:program withFlags:flags atRunPath:path withEnvironment:nil
+                 andWaiting:wait forTimeInterval:0 outputEncoding:NSUTF8StringEncoding];
+}
++(NSString*)runProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags withEnvironment:(NSDictionary*)env
+{
+    return [self runProgram:program withFlags:flags atRunPath:@"/" withEnvironment:env
+                 andWaiting:YES forTimeInterval:0 outputEncoding:NSUTF8StringEncoding];
+}
++(NSString*)runProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags atRunPath:(NSString*)path withEnvironment:(NSDictionary*)env
+{
+    return [self runProgram:program withFlags:flags atRunPath:path withEnvironment:env
+                 andWaiting:YES forTimeInterval:0 outputEncoding:NSUTF8StringEncoding];
+}
++(NSString*)runProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags waitingForTimeInterval:(unsigned int)timeout
+{
+    return [self runProgram:program withFlags:flags atRunPath:@"/" withEnvironment:nil
+                 andWaiting:YES forTimeInterval:timeout outputEncoding:NSUTF8StringEncoding];
+}
+
++(void)runAsynchronousProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags withEnvironment:(NSDictionary*)env
+{
+    [self runProgram:program withFlags:flags atRunPath:@"/" withEnvironment:env
+          andWaiting:NO forTimeInterval:0 outputEncoding:NSUTF8StringEncoding];
+}
++(void)runAsynchronousProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags atRunPath:(NSString*)path withEnvironment:(NSDictionary*)env
+{
+    [self runProgram:program withFlags:flags atRunPath:path withEnvironment:env
+          andWaiting:NO forTimeInterval:0 outputEncoding:NSUTF8StringEncoding];
+}
+
++(NSString*)runProgram:(NSString*)program withFlags:(NSArray<NSString*>*)flags atRunPath:(NSString*)path withEnvironment:(NSDictionary*)env andWaiting:(BOOL)wait forTimeInterval:(unsigned int)timeout outputEncoding:(NSStringEncoding)encoding
+{
+    if (program && ![program hasPrefix:@"/"])
+    {
+        NSString* newProgramPath = [self getPathOfProgram:program withEnvironment:env];
+        
+        if (newProgramPath == nil)
+        {
+            [VMMAlert showAlertOfType:VMMAlertTypeError
+                          withMessage:[NSString stringWithFormat:VMMLocalizedString(@"Path for %@ not found."), program]];
+            return @"";
+        }
+        
+        program = newProgramPath;
+    }
+    
+#ifdef DEBUG
+    if (path && flags)        NSDebugLog(@"Running %@ at path %@ with flags %@",program,path,[flags componentsJoinedByString:@" "]);
+    else if (path && !flags)  NSDebugLog(@"Running %@ at path %@",program,path);
+    else if (!path && flags)  NSDebugLog(@"Running %@ with flags %@",program,[flags componentsJoinedByString:@" "]);
+    else if (!path && !flags) NSDebugLog(@"Running %@",program);
+#endif
+    
+    if (path != nil && ![path hasSuffix:@"/"]) path = [path stringByAppendingString:@"/"];
+    
+    if (![[NSFileManager defaultManager] fileExistsAtPath:program])
+    {
+        [VMMAlert showAlertOfType:VMMAlertTypeError
+                      withMessage:[NSString stringWithFormat:VMMLocalizedString(@"File %@ not found."), program]];
+        return @"";
+    }
+    
+    if (![[NSFileManager defaultManager] isExecutableFileAtPath:program])
+    {
+        [VMMAlert showAlertOfType:VMMAlertTypeError
+                      withMessage:[NSString stringWithFormat:VMMLocalizedString(@"File %@ not runnable."), program]];
+        return @"";
+    }
+    
+    if (path && ![[NSFileManager defaultManager] directoryExistsAtPath:path])
+    {
+        [VMMAlert showAlertOfType:VMMAlertTypeError
+                      withMessage:[NSString stringWithFormat:VMMLocalizedString(@"Directory %@ does not exists."), path]];
+        return @"";
+    }
+    
+    @autoreleasepool
+    {
+        @try
+        {
+            NSTask *server = [NSTask new];
+            [server setLaunchPath:program];
+            if (path != nil)  [server setCurrentDirectoryPath:path];
+            if (flags != nil) [server setArguments:flags];
+            if (env != nil)   [server setEnvironment:env];
+            
+            NSFileHandle *errorFileHandle = [NSFileHandle fileHandleWithNullDevice];
+            [server setStandardError:errorFileHandle];
+            
+            if (!wait)
+            {
+                [server setStandardInput:[NSPipe pipe]];
+                [server launch];
+                
+                NSDebugLog(@"Instruction finished");
+                return @"";
+            }
+            
+            NSPipe *outputPipe = [NSPipe pipe];
+            [server setStandardInput:[NSPipe pipe]];
+            [server setStandardOutput:outputPipe];
+            [server launch];
+            
+            if (timeout == 0)
+            {
+                [server waitUntilExit];
+            }
+            else
+            {
+                __block NSCondition* lock = [[NSCondition alloc] init];
+                
+                [NSThread dispatchQueueWithName:"wait-until-task-exit" priority:DISPATCH_QUEUE_PRIORITY_DEFAULT concurrent:NO withBlock:^
+                {
+                    [server waitUntilExit];
+                    
+                    @synchronized (lock)
+                    {
+                        if (lock != nil) [lock signal];
+                    }
+                }];
+                
+                [NSThread dispatchQueueWithName:"wait-to-kill-task" priority:DISPATCH_QUEUE_PRIORITY_DEFAULT concurrent:NO withBlock:^
+                {
+                    [NSThread sleepForTimeInterval:timeout];
+                    
+                    @synchronized (lock)
+                    {
+                        if (lock != nil)
+                        {
+                            [lock signal];
+                            [server terminate];
+                        }
+                    }
+                }];
+                
+                [lock lock];
+                [lock wait];
+                [lock unlock];
+                lock = nil;
+            }
+            
+            NSFileHandle *file = [outputPipe fileHandleForReading];
+            NSData *outputData = [file readDataToEndOfFile];
+            [file closeFile];
+            
+            NSDebugLog(@"Instruction finished");
+            return [[NSString alloc] initWithData:outputData encoding:encoding];
+        }
+        @catch (NSException* exception)
+        {
+            // Sometimes (very rarely) the app might fail to retrieve the output of a command; with that, your app won't stop
+            NSDebugLog(@"Failed to retrieve instruction output: %@", exception.reason);
+            return @"";
+        }
+    }
+}
+
++(NSString*)getPathOfProgram:(NSString*)programName
+{
+    return [self getPathOfProgram:programName withEnvironment:nil];
+}
++(NSString*)getPathOfProgram:(NSString*)programName withEnvironment:(NSDictionary*)env
+{
+    if (programName == nil) return nil;
+    if (binaryPaths != nil && binaryPaths[programName]) return binaryPaths[programName];
+    
+    NSString* programPath;
+    
+    @autoreleasepool
+    {
+        if (binaryPaths == nil) binaryPaths = [[NSMutableDictionary alloc] init];
+        
+        programPath = [self runProgram:@"/usr/bin/type" withFlags:@[@"-a",programName] withEnvironment:env];
+        if (programPath == nil) return nil;
+        
+        programPath = [[programPath componentsSeparatedByString:@" "] lastObject];
+        if (programPath.length == 0) return nil;
+        
+        programPath = [programPath substringToIndex:programPath.length-1];
+    }
+    
+    if (programPath != nil) binaryPaths[programName] = programPath;
+    return programPath;
+}
+
+@end
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSText+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSText+Extension.h
@@ -1,0 +1,31 @@
+//
+//  NSText+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#ifndef NSText_Extension_Class
+#define NSText_Extension_Class
+
+#import <Cocoa/Cocoa.h>
+
+@interface NSText (VMMText)
+-(void)setSelectedRangeAsTheBeginOfTheField;
+-(void)setSelectedRangeAsTheEndOfTheField;
+@end
+
+@interface NSTextView (VMMTextView)
+-(void)setJustifiedAttributedString:(NSAttributedString*)string withColor:(NSColor*)color;
+-(void)deselectText;
+-(void)scrollToBottom;
+@end
+
+@interface NSTextField (VMMTextField)
+-(void)setSelectedRangeAsTheBeginOfTheField;
+-(void)setSelectedRangeAsTheEndOfTheField;
+-(void)setAnyStringValue:(NSString*)stringValue;
+@end
+
+#endif

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSText+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSText+Extension.m
@@ -1,0 +1,78 @@
+//
+//  NSText+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSText+Extension.h"
+
+#import "NSMutableAttributedString+Extension.h"
+
+#import "VMMComputerInformation.h"
+
+@implementation NSText (VMMText)
+-(void)setSelectedRangeAsTheBeginOfTheField
+{
+    [self setSelectedRange:NSMakeRange(0,0)];
+}
+-(void)setSelectedRangeAsTheEndOfTheField
+{
+    [self setSelectedRange:NSMakeRange(self.string.length,0)];
+}
+@end
+
+@implementation NSTextView (VMMTextView)
+-(void)setJustifiedAttributedString:(NSAttributedString*)string withColor:(NSColor*)color
+{
+    NSMutableAttributedString* str = string ? [string mutableCopy] : [[NSMutableAttributedString alloc] init];
+    
+    [self scrollRangeToVisible:NSMakeRange(0,0)];
+    [self setSelectedRange:NSMakeRange(0, 0)];
+    
+    if (color != nil) [str setFontColor:color];
+    
+    // NSTextAlignment values changed in macOS 10.11
+    // https://developer.apple.com/library/content/releasenotes/AppKit/RN-AppKitOlderNotes/index.html#10_11DynamicTracking
+    
+    [str setTextJustified];
+    
+    [[self textStorage] setAttributedString:str];
+}
+-(void)deselectText
+{
+    [self setSelectable:NO];
+    [self setSelectable:YES];
+}
+-(void)scrollToBottom
+{
+    // Reference:
+    // https://stackoverflow.com/a/28708474/4370893 
+    
+    NSPoint pt = NSMakePoint(0, 100000000000.0);
+    
+    id scrollView = [self enclosingScrollView];
+    id clipView = [scrollView contentView];
+    
+    pt = [clipView constrainScrollPoint:pt];
+    [clipView scrollToPoint:pt];
+    [scrollView reflectScrolledClipView:clipView];
+}
+@end
+
+@implementation NSTextField (VMMTextField)
+-(void)setSelectedRangeAsTheBeginOfTheField
+{
+    [[self currentEditor] setSelectedRangeAsTheBeginOfTheField];
+}
+-(void)setSelectedRangeAsTheEndOfTheField
+{
+    [[self currentEditor] setSelectedRangeAsTheEndOfTheField];
+}
+-(void)setAnyStringValue:(NSString*)stringValue
+{
+    [self setStringValue:stringValue ? stringValue : @""];
+}
+@end
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSThread+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSThread+Extension.h
@@ -1,0 +1,29 @@
+//
+//  NSThread+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#ifndef NSThread_Extension_Class
+#define NSThread_Extension_Class
+
+#import <Foundation/Foundation.h>
+
+#define threadSafeUiValue(__value)   [NSThread returnThreadSafeBlock:^id{ return (__value); }]
+
+dispatch_queue_t queueWithNameAndPriority(const char* name, long priority, BOOL concurrent);
+
+@interface NSThread (VMMThread)
+
++(void)dispatchQueueWithName:(const char*)name priority:(long)priority concurrent:(BOOL)concurrent withBlock:(void (^)(void))thread;
++(void)dispatchBlockInMainQueue:(void (^)(void))thread;
+
++(void)runThreadSafeBlock:(void (^)(void))block;
+
++(id)returnThreadSafeBlock:(id (^)(void))block;
+
+@end
+
+#endif

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSThread+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSThread+Extension.m
@@ -1,0 +1,85 @@
+//
+//  NSThread+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSThread+Extension.h"
+
+dispatch_queue_t queueWithNameAndPriority(const char* name, long priority, BOOL concurrent)
+{
+    dispatch_queue_t dispatchQueue = dispatch_queue_create(name, concurrent ? DISPATCH_QUEUE_CONCURRENT : DISPATCH_QUEUE_SERIAL);
+    dispatch_queue_t priorityQueue = dispatch_get_global_queue(priority, 0);
+    dispatch_set_target_queue(dispatchQueue, priorityQueue);
+    return dispatchQueue;
+}
+
+@implementation NSThread (VMMThread)
+
++(void)dispatchQueueWithName:(const char*)name priority:(long)priority concurrent:(BOOL)concurrent withBlock:(void (^)(void))thread
+{
+    dispatch_async(queueWithNameAndPriority(name, priority, concurrent), ^
+    {
+        thread();
+    });
+}
++(void)dispatchBlockInMainQueue:(void (^)(void))thread
+{
+    dispatch_async(dispatch_get_main_queue(), ^
+    {
+        thread();
+    });
+}
+
++(void)runThreadSafeBlock:(void (^)(void))block
+{
+    if ([NSThread isMainThread])
+    {
+        block();
+    }
+    else
+    {
+        NSCondition* lock = [[NSCondition alloc] init];
+        
+        [NSThread dispatchBlockInMainQueue:^
+         {
+             block();
+             
+             [lock signal];
+         }];
+        
+        [lock lock];
+        [lock wait];
+        [lock unlock];
+    }
+}
+
++(id)returnThreadSafeBlock:(id (^)(void))block
+{
+    if ([NSThread isMainThread])
+    {
+        return block();
+    }
+    else
+    {
+        __block id object;
+        NSCondition* lock = [[NSCondition alloc] init];
+        
+        [NSThread dispatchBlockInMainQueue:^
+        {
+             object = block();
+             
+             [lock signal];
+        }];
+        
+        [lock lock];
+        [lock wait];
+        [lock unlock];
+        
+        return object;
+    }
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSTimer+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSTimer+Extension.h
@@ -1,0 +1,24 @@
+//
+//  NSTimer+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 23/11/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface VMMTimerListener : NSObject
+
+@property (nonatomic, strong) NSTimer* _Nullable timer;
+@property (nonatomic, strong) void (^block)(NSTimer* timer);
+
+@end
+
+@interface NSTimer (VMMTimer)
+
++(nonnull NSTimer*)scheduledTimerWithRunLoopMode:(nonnull NSRunLoopMode)runLoopMode timeInterval:(NSTimeInterval)interval target:(nonnull id)target selector:(nonnull SEL)selector userInfo:(nullable id)userInfo;
+
++(nonnull VMMTimerListener*)scheduledTimerWithRunLoopMode:(nonnull NSRunLoopMode)runLoopMode timeInterval:(NSTimeInterval)interval repeats:(BOOL)repeats block:(void (^)(NSTimer* _Nonnull timer))block;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSTimer+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSTimer+Extension.m
@@ -1,0 +1,42 @@
+//
+//  NSTimer+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 23/11/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import "NSTimer+Extension.h"
+#import "VMMComputerInformation.h"
+
+@implementation VMMTimerListener
+
+-(void)listen {
+    _block(_timer);
+}
+
+@end
+
+@implementation NSTimer (VMMTimer)
+
++(nonnull NSTimer*)scheduledTimerWithRunLoopMode:(nonnull NSRunLoopMode)runLoopMode timeInterval:(NSTimeInterval)interval target:(nonnull id)target selector:(nonnull SEL)selector userInfo:(nullable id)userInfo
+{
+    NSTimer* timer = [NSTimer scheduledTimerWithTimeInterval:interval target:target selector:selector userInfo:userInfo repeats:YES];
+    NSRunLoop* theRunLoop = [NSRunLoop currentRunLoop];
+    [theRunLoop addTimer:timer forMode:runLoopMode];
+    return timer;
+}
+
++(nonnull VMMTimerListener*)scheduledTimerWithRunLoopMode:(nonnull NSRunLoopMode)runLoopMode timeInterval:(NSTimeInterval)interval repeats:(BOOL)repeats block:(void (^)(NSTimer* _Nonnull timer))block
+{
+    VMMTimerListener* listener = [[VMMTimerListener alloc] init];
+    listener.block = block;
+    listener.timer = [NSTimer timerWithTimeInterval:interval target:listener selector:@selector(listen) userInfo:nil repeats:repeats];
+    
+    NSRunLoop* theRunLoop = [NSRunLoop currentRunLoop];
+    [theRunLoop addTimer:listener.timer forMode:runLoopMode];
+    return listener;
+}
+
+@end
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSUnarchiver+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSUnarchiver+Extension.h
@@ -1,0 +1,21 @@
+//
+//  NSUnarchiver+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#ifndef NSUnarchiver_Extension_Class
+#define NSUnarchiver_Extension_Class
+
+#import <Foundation/Foundation.h>
+
+@interface NSUnarchiver (VMMUnarchiver)
+
++(nullable id)safeUnarchiveObjectWithData:(nonnull NSData*)data;
++(nullable id)safeUnarchiveObjectFromFile:(nonnull NSString*)path;
+
+@end
+
+#endif

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSUnarchiver+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSUnarchiver+Extension.m
@@ -1,0 +1,43 @@
+//
+//  NSUnarchiver+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSUnarchiver+Extension.h"
+
+#import "NSData+Extension.h"
+
+@implementation NSUnarchiver (VMMUnarchiver)
+
++(nullable id)safeUnarchiveObjectWithData:(nonnull NSData*)data
+{
+    @try
+    {
+        return [self unarchiveObjectWithData:data];
+    }
+    @catch (NSException *exception)
+    {
+        return nil;
+    }
+}
++(nullable id)safeUnarchiveObjectFromFile:(nonnull NSString*)path
+{
+    if (![[NSFileManager defaultManager] fileExistsAtPath:path]) return nil;
+    
+    id contents = nil;
+    
+    @autoreleasepool
+    {
+        NSData* data = [NSData safeDataWithContentsOfFile:path];
+        if (!data || data.length == 0) return nil;
+        
+        contents = [self safeUnarchiveObjectWithData:data];
+    }
+        
+    return contents;
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSUserDefaults+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSUserDefaults+Extension.h
@@ -1,0 +1,18 @@
+//
+//  NSUserDefaults+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 31/08/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSUserDefaults (VMMUserDefaults)
+
+-(nonnull id)objectForKey:(nonnull NSString *)key withDefaultValue:(nonnull id)value;
+
+-(BOOL)preferExternalGPU;
+-(void)setPreferExternalGPU:(BOOL)prefer;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSUserDefaults+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSUserDefaults+Extension.m
@@ -1,0 +1,55 @@
+//
+//  NSUserDefaults+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 31/08/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSUserDefaults+Extension.h"
+
+#import "VMMComputerInformation.h"
+#import "VMMLogUtility.h"
+
+@implementation NSUserDefaults (VMMUserDefaults)
+
+-(nonnull id)objectForKey:(nonnull NSString *)key withDefaultValue:(nonnull id)value
+{
+    id actualValue = [self objectForKey:key];
+    
+    if (actualValue == nil)
+    {
+        [self setObject:value forKey:key];
+        return value;
+    }
+    
+    return actualValue;
+}
+
+-(BOOL)preferExternalGPU
+{
+    // Reference:
+    // https://egpu.io/forums/mac-setup/potentially-accelerate-all-applications-on-egpu-macos-10-13-4/
+    
+    if ([VMMComputerInformation macOsCompatibilityWithExternalGPU] != VMMExternalGPUCompatibilityWithMacOS_Supported) {
+        NSDebugLog(@"\"Prefer External GPU\" was not available prior to macOS 10.13.4. Using that probably wont't change anything.");
+    }
+    
+    NSString* appReturn = [self objectForKey:@"GPUSelectionPolicy"];
+    return appReturn != nil && [appReturn isKindOfClass:[NSString class]] && [appReturn isEqualToString:@"preferRemovable"];
+}
+-(void)setPreferExternalGPU:(BOOL)prefer
+{
+    if ([VMMComputerInformation macOsCompatibilityWithExternalGPU] != VMMExternalGPUCompatibilityWithMacOS_Supported) {
+        NSDebugLog(@"\"Prefer External GPU\" was not available prior to macOS 10.13.4. Using that probably wont't change anything.");
+    }
+    
+    if (prefer) {
+        [self setObject:@"preferRemovable" forKey:@"GPUSelectionPolicy"];
+    }
+    else {
+        [self removeObjectForKey:@"GPUSelectionPolicy"];
+    }
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSView+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSView+Extension.h
@@ -1,0 +1,15 @@
+//
+//  NSView+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 04/09/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface NSView (VMMView_Extensions)
+
+-(void)removeAllSubviews;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSView+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSView+Extension.m
@@ -1,0 +1,22 @@
+//
+//  NSView+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 04/09/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "NSView+Extension.h"
+
+@implementation NSView (VMMView_Extensions)
+
+-(void)removeAllSubviews
+{
+    NSArray* subviewsArray = [self subviews];
+    for (int i = (int)subviewsArray.count - 1; i >= 0 ; i--)
+    {
+        [subviewsArray[i] removeFromSuperview];
+    }
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSWorkspace+Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSWorkspace+Extension.h
@@ -1,0 +1,17 @@
+//
+//  NSWorkspace+Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 24/11/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface NSWorkspace (VMMWorkspace)
+
+-(nonnull NSArray<NSRunningApplication*>*)runningApplicationsFromInsideBundle:(nonnull NSString*)bundlePath;
+
+-(void)forceOpenURL:(nonnull NSURL*)url;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/NSWorkspace+Extension.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/NSWorkspace+Extension.m
@@ -1,0 +1,53 @@
+//
+//  NSWorkspace+Extension.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 24/11/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import "NSWorkspace+Extension.h"
+
+#import "NSTask+Extension.h"
+
+@implementation NSWorkspace (VMMWorkspace)
+
+-(nonnull NSArray<NSRunningApplication*>*)runningApplicationsFromInsideBundle:(nonnull NSString*)bundlePath
+{
+    NSMutableArray* list = [[NSMutableArray alloc] init];
+    
+    @autoreleasepool
+    {
+        for (NSRunningApplication* runningApp in [self runningApplications])
+        {
+            NSString* binLocalPath = [[runningApp executableURL] path];
+            
+            if (binLocalPath != nil)
+            {
+                if (![binLocalPath hasPrefix:bundlePath] && [bundlePath hasPrefix:@"/private"])
+                {
+                    binLocalPath = [@"/private" stringByAppendingString:binLocalPath];
+                }
+                
+                if ([binLocalPath hasPrefix:bundlePath])
+                {
+                    [list addObject:runningApp];
+                }
+            }
+        }
+    }
+    
+    return list;
+}
+
+-(void)forceOpenURL:(nonnull NSURL*)url
+{
+    BOOL opened = [self openURL:url];
+    
+    if (opened == false)
+    {
+        [NSTask runProgram:@"open" withFlags:@[url.absoluteString]];
+    }
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/ObjCExtensionConfig.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/ObjCExtensionConfig.h
@@ -1,0 +1,94 @@
+//
+//  ObjCExtensionConfig.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/08/18.
+//  Copyright © 2018 VitorMM. All rights reserved.
+//
+
+#ifndef ObjCExtensionConfig_h
+#define ObjCExtensionConfig_h
+
+
+#define I_WANT_TO_BE_RELEASED_IN_APPLE_STORE  false
+//
+// Pretty straightforward. If you set this to TRUE, any of the conditions
+// below that may cause a rejection in the Apple Store will be automatically
+// disabled in the end of this file.
+//
+
+
+
+#define NSDEBUGLOG_SHOULD_PRINT_TO_A_DESKTOP_FILE_TOO  false
+//
+// By enabling this, NSDebugLog should not only run as NSLog white in Debug,
+// but it should also create a debug.log file in your Desktop with the same
+// content. It's really useful in case you restart your app and lose some log,
+// and with Mojave's extra logs in the console, that gives you a source without
+// those extra contents.
+//
+
+
+
+#define USER_NOTIFICATIONS_SHOULD_SHOW_A_BIGGER_ICON  true
+//
+// User notifications have two different icons. A big one with the app icon
+// in the left, and a squared smaller one in the right with a thumbnail.
+//
+// If this is set to FALSE and you ask VMMUserNotificationCenter to show a
+// notification with an icon, it's going to show the icon in the right side
+// of the notification.
+//
+// If this is set to TRUE and you ask VMMUserNotificationCenter to show a
+// notification with an icon, it's going to show the icon in the left side
+// of the notification, and the app icon will appear with a smaller side
+// next to the notification title, in the left.
+//
+// WARNING: Setting this to TRUE will make your app be rejected
+// in the Apple Store.
+//
+
+
+
+#define USE_THE_OPENGL_FRAMEWORK_WHEN_AVAILABLE  true
+//
+// If you set this to TRUE, VMMComputerInformation will use the OpenGL framework to look
+// for video card information only if the OpenGL framework is available.
+//
+// If you set this to FALSE, you will need to import the OpenGL framework (and enable the
+// define below) to use the videoCardMemorySizesInMegabytesFromOpenGLAPI function of VMMVideoCard.
+//
+// WARNING: Setting this to TRUE will make your app be rejected
+// in the Apple Store.
+//
+
+
+
+#define IM_IMPORTING_THE_OPENGL_FRAMEWORK  false
+//
+// If you import the OpenGL Framework, your app will be macOS 10.14- compatible only.
+// https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/opengl_intro/opengl_intro.html
+//
+// If you want to use the VMMVideoCard videoCardMemorySizesInMegabytesFromOpenGLAPI function and still be
+// released in the Apple Store, set this to TRUE and add the OpenGL Framework to this project.
+// Otherwise, you can safely set this function to FALSE. If this and USE_THE_OPENGL_FRAMEWORK_WHEN_AVAILABLE
+// are set to FALSE, the videoCardMemorySizesInMegabytesFromOpenGLAPI function won't be available.
+//
+
+
+
+// DO NOT CHANGE WHAT'S BELOW THIS POINT!
+// THIS IS WHAT MAKES THE I_WANT_TO_BE_RELEASED_IN_APPLE_STORE
+// CONDITION WORK!
+
+#if I_WANT_TO_BE_RELEASED_IN_APPLE_STORE == true
+    #define USER_NOTIFICATIONS_SHOULD_SHOW_A_BIGGER_ICON  false
+    #define USE_THE_OPENGL_FRAMEWORK_WHEN_AVAILABLE       false
+#endif
+
+
+
+#define KEEP_DEVICE_CLASSES true
+
+
+#endif /* ObjCExtensionConfig_h */

--- a/ObjectiveC_Extension/ObjectiveC_Extension/ObjectiveC_Extension.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/ObjectiveC_Extension.h
@@ -1,0 +1,81 @@
+//
+//  ObjectiveC_Extension.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 29/09/17.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+//! Project version number for ObjectiveC_Extension.
+FOUNDATION_EXPORT double ObjectiveC_ExtensionVersionNumber;
+
+//! Project version string for ObjectiveC_Extension.
+FOUNDATION_EXPORT const unsigned char ObjectiveC_ExtensionVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <ObjectiveC_Extension/PublicHeader.h>
+
+#import <ObjectiveC_Extension/ObjCExtensionConfig.h>
+
+// Devices
+#if KEEP_DEVICE_CLASSES == true
+#import <ObjectiveC_Extension/VMMVirtualKeycode.h>
+#import <ObjectiveC_Extension/VMMDeviceObserver.h>
+#import <ObjectiveC_Extension/VMMDeviceSimulator.h>
+#import <ObjectiveC_Extension/VMMUsageKeycode.h>
+#endif
+
+// Extensions
+#import <ObjectiveC_Extension/NSApplication+Extension.h>
+#import <ObjectiveC_Extension/NSArray+Extension.h>
+#import <ObjectiveC_Extension/NSAttributedString+Extension.h>
+#import <ObjectiveC_Extension/NSBundle+Extension.h>
+#import <ObjectiveC_Extension/NSColor+Extension.h>
+#import <ObjectiveC_Extension/NSData+Extension.h>
+#import <ObjectiveC_Extension/NSDateFormatter+Extension.h>
+#import <ObjectiveC_Extension/NSException+Extension.h>
+#import <ObjectiveC_Extension/NSFileManager+Extension.h>
+#import <ObjectiveC_Extension/NSImage+Extension.h>
+#import <ObjectiveC_Extension/NSMenuItem+Extension.h>
+#import <ObjectiveC_Extension/NSMutableArray+Extension.h>
+#import <ObjectiveC_Extension/NSMutableAttributedString+Extension.h>
+#import <ObjectiveC_Extension/NSMutableDictionary+Extension.h>
+#import <ObjectiveC_Extension/NSMutableString+Extension.h>
+#import <ObjectiveC_Extension/NSMutableURLRequest+Extension.h>
+#import <ObjectiveC_Extension/NSRunningApplication+Extension.h>
+#import <ObjectiveC_Extension/NSSavePanel+Extension.h>
+#import <ObjectiveC_Extension/NSScreen+Extension.h>
+#import <ObjectiveC_Extension/NSString+Extension.h>
+#import <ObjectiveC_Extension/NSTask+Extension.h>
+#import <ObjectiveC_Extension/NSText+Extension.h>
+#import <ObjectiveC_Extension/NSThread+Extension.h>
+#import <ObjectiveC_Extension/NSTimer+Extension.h>
+#import <ObjectiveC_Extension/NSUnarchiver+Extension.h>
+#import <ObjectiveC_Extension/NSUserDefaults+Extension.h>
+#import <ObjectiveC_Extension/NSView+Extension.h>
+#import <ObjectiveC_Extension/NSWorkspace+Extension.h>
+
+// Utilities
+#import <ObjectiveC_Extension/NKFTPManager.h>
+#import <ObjectiveC_Extension/VMMComputerInformation.h>
+#import <ObjectiveC_Extension/VMMVideoCard.h>
+#import <ObjectiveC_Extension/VMMVideoCardManager.h>
+#import <ObjectiveC_Extension/VMMDockProgressIndicator.h>
+#import <ObjectiveC_Extension/VMMLocalizationUtility.h>
+#import <ObjectiveC_Extension/VMMLogUtility.h>
+#import <ObjectiveC_Extension/VMMModals.h>
+#import <ObjectiveC_Extension/VMMParentalControls.h>
+#import <ObjectiveC_Extension/VMMPropertyList.h>
+#import <ObjectiveC_Extension/VMMUserNotificationCenter.h>
+#import <ObjectiveC_Extension/VMMVersion.h>
+#import <ObjectiveC_Extension/VMMUUID.h>
+
+// Views
+#import <ObjectiveC_Extension/VMMKeyCaptureField.h>
+#import <ObjectiveC_Extension/VMMAlert.h>
+#import <ObjectiveC_Extension/VMMMenu.h>
+#import <ObjectiveC_Extension/VMMView.h>
+#import <ObjectiveC_Extension/VMMWebView.h>
+#import <ObjectiveC_Extension/VMMTextFileView.h>
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/SZJsonParser.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/SZJsonParser.h
@@ -1,0 +1,27 @@
+//
+//  SZJsonParser.h
+//  JSON Parser
+//
+//  Created by numata on 09/09/04.
+//  Copyright 2009 Satoshi Numata. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SZJsonParser : NSObject
+{
+    NSString    *mSource;
+    NSUInteger  mLength;
+    NSUInteger  mPos;
+}
+
+- (id)initWithSource:(NSString *)source;
+- (id)parse;
+
+@end
+
+@interface NSString (JsonParser)
+
+- (id)jsonObject;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/SZJsonParser.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/SZJsonParser.m
@@ -1,0 +1,468 @@
+//
+//  SZJsonParser.m
+//  JSON Parser
+//
+//  Created by numata on 09/09/04.
+//  Copyright 2009 Satoshi Numata. All rights reserved.
+//
+
+#import "SZJsonParser.h"
+
+#import "VMMLogUtility.h"
+
+@interface SZJsonParser ()
+
+- (BOOL)hasMoreCharacters;
+- (unichar)lookAtNextCharacter;
+- (unichar)getNextCharacter;
+
+- (void)skipCharacter;
+- (void)skipWhiteSpaces;
+
+- (void)skipLineComment;
+- (void)skipNormalComment;
+- (void)skipComment;
+- (NSString *)parseString;
+- (NSNumber *)parseTrue;
+- (NSNumber *)parseFalse;
+- (NSNumber *)parseNumber;
+- (NSNull *)parseNull;
+- (NSArray *)parseArray;
+- (NSDictionary *)parseHashTable;
+- (id)parseObject;
+
+@end
+
+
+@implementation SZJsonParser
+
+- (id)initWithSource:(NSString *)source
+{
+    self = [super init];
+    if (self) {
+        mSource = source;
+        mLength = [source length];
+    }
+    return self;
+}
+
+
+#pragma mark -
+#pragma mark JSON Parsing Utilities
+
+- (BOOL)hasMoreCharacters
+{
+    return (mPos < mLength);
+}
+
+- (unichar)lookAtNextCharacter
+{
+    if (mPos >= mLength) {
+        @throw [NSException exceptionWithName:@"JSON Parsing Error"
+                                       reason:@"Unexpected end of source string."
+                                     userInfo:nil];
+    }
+    return [mSource characterAtIndex:mPos];
+}
+
+- (unichar)getNextCharacter
+{
+    if (mPos >= mLength) {
+        @throw [NSException exceptionWithName:@"JSON Parsing Error"
+                                       reason:@"Unexpected end of source string."
+                                     userInfo:nil];
+    }
+    return [mSource characterAtIndex:mPos++];
+}
+
+- (NSString *)getNextString:(NSUInteger)length
+{
+    if (mPos + length > mLength) {
+        @throw [NSException exceptionWithName:@"JSON Parsing Error"
+                                       reason:@"Unexpected end of source string."
+                                     userInfo:nil];
+    }
+    NSString *ret = [mSource substringWithRange:NSMakeRange(mPos, length)];
+    mPos += length;
+    return ret;
+}
+
+- (void)skipCharacter
+{
+    mPos++;
+}
+
+- (void)skipWhiteSpaces
+{
+    while ([self hasMoreCharacters]) {
+        unichar c = [self lookAtNextCharacter];
+        if (!isspace((int)c)) {
+            break;
+        }
+        [self skipCharacter];
+    }
+}
+
+
+#pragma mark -
+#pragma mark JSON Parsing Implementation
+
+- (void)skipLineComment
+{
+    [self skipCharacter];   // '/'
+    
+    while ([self hasMoreCharacters]) {
+        unichar c = [self getNextCharacter];
+        if (c == '\r' || c == '\n') {
+            break;
+        }
+    }
+}
+
+- (void)skipNormalComment
+{
+    [self skipCharacter];   // '*'
+    
+    while ([self hasMoreCharacters]) {
+        unichar c = [self getNextCharacter];
+        if (c == '*') {
+            c = [self lookAtNextCharacter];
+            if (c == '/') {
+                [self skipCharacter];
+                break;
+            }
+        }
+    }
+}
+
+- (void)skipComment
+{
+    [self skipCharacter];
+    
+    unichar c = [self lookAtNextCharacter];
+    if (c == '/') {
+        [self skipLineComment];
+    } else if (c == '*') {
+        [self skipNormalComment];
+    } else {
+        @throw [NSException exceptionWithName:@"JSON Parsing Error"
+                                       reason:@"Illegal comment beginning."
+                                     userInfo:nil];
+    }
+}
+
+- (void)skipWhiteSpacesAndComments
+{
+    unichar c = [self lookAtNextCharacter];
+    
+    while (YES) {
+        if (isspace((int)c)) {
+            [self skipWhiteSpaces];
+        } else if (c == '/') {
+            [self skipComment];
+        } else {
+            break;
+        }
+        
+        c = [self lookAtNextCharacter];
+    }
+}
+
+- (NSString *)parseString
+{
+    unichar c1 = [self getNextCharacter];
+    
+    int stringEdgeType;     // 0:Double quotation, 1:Single quotation
+    
+    if (c1 == '"') {
+        stringEdgeType = 0;
+    } else if (c1 == '\'') {
+        stringEdgeType = 1;
+    } else {
+        @throw [NSException exceptionWithName:@"JSON Parsing Error"
+                                       reason:@"Illegal string start character."
+                                     userInfo:nil];
+    }
+    
+    NSMutableString *ret = [NSMutableString string];
+    
+    BOOL isEscaped = NO;
+    while ([self hasMoreCharacters]) {
+        unichar c = [self getNextCharacter];
+        if (!isEscaped && ((stringEdgeType == 0 && c == '"') || (stringEdgeType == 1 && c == '\''))) {
+            break;
+        }
+        if (!isEscaped) {
+            if (c == '\\') {
+                isEscaped = YES;
+            } else {
+                [ret appendFormat:@"%C", c];
+            }
+        } else {
+                 if (c == '"' ) {[ret appendString:@"\""];}
+            else if (c == '\'') {[ret appendString:@"'" ];}
+            else if (c == '\\') {[ret appendString:@"\\"];}
+            else if (c == '/' ) {[ret appendString:@"/" ];}
+            else if (c == 'b' ) {[ret appendString:@"\b"];}
+            else if (c == 'f' ) {[ret appendString:@"\f"];}
+            else if (c == 'n' ) {[ret appendString:@"\n"];}
+            else if (c == 'r' ) {[ret appendString:@"\r"];}
+            else if (c == 't' ) {[ret appendString:@"\t"];}
+            else if (c == 'u' ) {
+                NSString *fourHexDigits = [self getNextString:4];
+                NSScanner *scanner = [NSScanner scannerWithString:fourHexDigits];
+                unsigned charCode;
+                if ([scanner scanHexInt:&charCode]) {
+                    [ret appendFormat:@"%C", (unichar)charCode];
+                } else {
+                    @throw [NSException exceptionWithName:@"JSON Parsing Error"
+                                                   reason:[NSString stringWithFormat:@"Illegal unicode character (u%@).", fourHexDigits]
+                                                 userInfo:nil];
+                }
+            }
+            else
+            {
+                // Seems to fix the issue that may occur with base 64 strings inside a JSON
+                [ret appendString:[NSString stringWithFormat:@"%c",c]];
+            }
+            isEscaped = NO;
+        }
+    }
+    
+    return ret;
+}
+
+- (NSNumber *)parseTrue
+{
+    NSString *str = [self getNextString:4];
+    
+    if (![str isEqualToString:@"true"]) {
+        @throw [NSException exceptionWithName:@"JSON Parsing Error"
+                                       reason:@"Illegal character appeared."
+                                     userInfo:nil];
+    }
+    
+    return [NSNumber numberWithBool:YES];
+}
+
+- (NSNumber *)parseFalse
+{
+    NSString *str = [self getNextString:5];
+    
+    if (![str isEqualToString:@"false"]) {
+        @throw [NSException exceptionWithName:@"JSON Parsing Error"
+                                       reason:@"Illegal character appeared."
+                                     userInfo:nil];
+    }
+    
+    return [NSNumber numberWithBool:NO];
+}
+
+- (NSNumber *)parseNumber
+{
+    NSCharacterSet *numberSet = [NSCharacterSet characterSetWithCharactersInString:@"+-.eE0123456789"];
+    
+    NSMutableString *numberStr = [NSMutableString string];
+    
+    BOOL isFloat = NO;
+    
+    while ([self hasMoreCharacters]) {
+        unichar c = [self lookAtNextCharacter];
+        if (![numberSet characterIsMember:c]) {
+            break;
+        }
+        if (c == '.' || c == 'e' || c == 'E') {
+            isFloat = YES;
+        }
+        [numberStr appendFormat:@"%C", c];
+        [self skipCharacter];
+    }
+    
+    NSNumber *ret;
+    NSScanner *scanner = [NSScanner scannerWithString:numberStr];
+    
+    if (isFloat) {
+        float floatValue;
+        if ([scanner scanFloat:&floatValue]) {
+            ret = [NSNumber numberWithFloat:floatValue];
+        } else {
+            @throw [NSException exceptionWithName:@"JSON Parsing Error"
+                                           reason:@"Illegal number format."
+                                         userInfo:nil];
+        }
+    } else {
+        int intValue;
+        if ([scanner scanInt:&intValue]) {
+            ret = [NSNumber numberWithInt:intValue];
+        } else {
+            @throw [NSException exceptionWithName:@"JSON Parsing Error"
+                                           reason:@"Illegal number format."
+                                         userInfo:nil];
+        }
+    }
+    
+    return ret;
+}
+
+- (NSNull *)parseNull
+{
+    NSString *str = [self getNextString:4];
+    
+    if (![str isEqualToString:@"null"]) {
+        @throw [NSException exceptionWithName:@"JSON Parsing Error"
+                                       reason:@"Illegal character appeared."
+                                     userInfo:nil];
+    }
+    
+    return [NSNull null];
+}
+
+- (NSArray *)parseArray
+{
+    NSMutableArray *ret = [NSMutableArray array];
+    
+    [self skipCharacter];   // '['
+    
+    while (YES) {
+        [self skipWhiteSpacesAndComments];
+        
+        // Check for empty array or sudden end
+        if ([self lookAtNextCharacter] == ']') {
+            [self skipCharacter];
+            break;
+        }
+        
+        id anObj = [self parseObject];
+        [ret addObject:anObj];
+        
+        [self skipWhiteSpacesAndComments];
+        
+        unichar c = [self getNextCharacter];
+        if (c == ']') {
+            break;
+        } else if (c != ',') {
+            @throw [NSException exceptionWithName:@"JSON Parsing Error"
+                                           reason:@"Illegal array entry divider."
+                                         userInfo:nil];
+        }
+    }
+    
+    return ret;
+}
+
+- (NSDictionary *)parseHashTable
+{
+    NSMutableDictionary *ret = [NSMutableDictionary dictionary];
+    
+    [self skipCharacter];   // '{'
+    
+    while (YES) {
+        [self skipWhiteSpacesAndComments];
+        
+        // Check for empty table or sudden end
+        if ([self lookAtNextCharacter] == '}') {
+            [self skipCharacter];
+            break;
+        }
+        
+        NSString *keyStr = [self parseString];
+        
+        [self skipWhiteSpacesAndComments];
+        
+        unichar c1 = [self getNextCharacter];
+        if (c1 != ':') {
+            @throw [NSException exceptionWithName:@"JSON Parsing Error"
+                                           reason:@"Missing ':' after a key of a hash table."
+                                         userInfo:nil];
+        }
+        
+        [self skipWhiteSpacesAndComments];
+        
+        id valueObj = [self parseObject];
+        
+        [ret setObject:valueObj forKey:keyStr];
+        
+        [self skipWhiteSpacesAndComments];
+        
+        unichar c2 = [self getNextCharacter];
+        if (c2 == '}') {
+            break;
+        } else if (c2 != ',') {
+            @throw [NSException exceptionWithName:@"JSON Parsing Error"
+                                           reason:@"Illegal hash table entry divider."
+                                         userInfo:nil];
+        }
+    }
+    
+    return ret;
+}
+
+- (id)parseObject
+{
+    [self skipWhiteSpacesAndComments];
+    
+    unichar c = [self lookAtNextCharacter];
+    
+    if (c == '"' || c == '\'') {
+        return [self parseString];
+    } else if (c == '[') {
+        return [self parseArray];
+    } else if (c == '{') {
+        return [self parseHashTable];
+    } else if (isdigit((int)c) || c == '-' || c == '+' || c == '.') {
+        return [self parseNumber];
+    } else if (c == 't') {
+        return [self parseTrue];
+    } else if (c == 'f') {
+        return [self parseFalse];
+    } else if (c == 'n') {
+        return [self parseNull];
+    } else {
+        @throw [NSException exceptionWithName:@"JSON Parsing Error"
+                                       reason:[NSString stringWithFormat:@"Illegal Object Prefix: \'%C\' (0x%02x)", c, c]
+                                     userInfo:nil];
+    }
+    
+    return nil;
+}
+
+- (id)parseImpl
+{
+    mPos = 0;
+    
+    return [self parseObject];
+}
+
+
+#pragma mark -
+#pragma mark JSON Parser Interface
+
+- (id)parse
+{
+    id ret = nil;
+    @try {
+        ret = [self parseImpl];
+    }
+    @catch (NSException *e) {
+        NSDebugLog(@"JSON Parsing Error: %@", [e reason]);
+    }
+    return ret;
+}
+
+@end
+
+
+#pragma mark -
+
+@implementation NSString (JsonParser)
+
+- (id)jsonObject
+{
+    SZJsonParser *parser = [[SZJsonParser alloc] initWithSource:self];
+    
+    id obj = [parser parse];
+    
+    return obj;
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMAlert.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMAlert.h
@@ -1,0 +1,162 @@
+//
+//  VMMAlert.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#ifndef VMMAlert_Extension_Class
+#define VMMAlert_Extension_Class
+
+#import <Cocoa/Cocoa.h>
+
+/*!
+ * @typedef VMMAlertType
+ * @brief A list of predefined alert types.
+ * @constant VMMAlertTypeSuccess  An alert with 'Success' as title and the default alert icon.
+ * @constant VMMAlertTypeWarning  An alert with 'Warning' as title and the NSCriticalAlertStyle icon.
+ * @constant VMMAlertTypeError    An alert with 'Error' as title and NSImageNameCaution as icon.
+ * @constant VMMAlertTypeCritical An alert with 'Error' as title and NSImageNameStopProgressFreestandingTemplate as icon.
+ * @constant VMMAlertTypeCustom   An alert with the app name as title and the default alert icon.
+ */
+typedef enum VMMAlertType
+{
+    /// An alert with 'Success' as title and the default alert icon.
+    VMMAlertTypeSuccess,
+    
+    /// An alert with 'Warning' as title and the NSCriticalAlertStyle icon.
+    VMMAlertTypeWarning,
+    
+    /// An alert with 'Error' as title and NSImageNameCaution as icon.
+    VMMAlertTypeError,
+    
+    /// An alert with 'Error' as title and NSImageNameStopProgressFreestandingTemplate as icon.
+    VMMAlertTypeCritical,
+    
+    /// An alert with the app name as title and the default alert icon.
+    VMMAlertTypeCustom
+} VMMAlertType;
+
+@interface VMMAlert : NSAlert
+
+/*!
+ * @discussion  Changes the icon of a VMMAlert based in the VMMAlertType.
+ * @param alertType The VMMAlertType that will be used to configure the alert icon.
+ */
+-(void)setIconWithAlertType:(VMMAlertType)alertType;
+
+/*!
+ * @discussion  Same as runModal, but which runs the alert in the main thread and returns the result to the active thread.
+ * @discussion  This method is thread safe, so it can be used from any thread or queue.
+ * @return      The runModal output.
+ */
+-(NSUInteger)runThreadSafeModal;
+
+/*!
+ * @discussion  Same as runModal, but which creates and runs the alert in the main thread and returns the result to the active thread.
+ * @discussion  This method is thread safe, so it can be used from any thread or queue.
+ * @param alert A block that will be run in the main thread, and needs as return the VMMAlert that will be shown.
+ * @return      The runModal output.
+ */
++(NSUInteger)runThreadSafeModalWithAlert:(VMMAlert* (^)(void))alert;
+
+/*!
+ * @discussion  Shows a VMMAlert with the contents of a NSException and an Ok button.
+ * @discussion  This method is thread safe, so it can be used from any thread or queue.
+ * @param exception The exception that will be used to create the alert.
+ */
++(void)showErrorAlertWithException:(NSException*)exception;
+
+/*!
+ * @discussion  Shows a VMMAlert with a predefined VMMAlertType, an informative text and an Ok button.
+ * @discussion  This method is thread safe, so it can be used from any thread or queue.
+ * @param alertType The VMMAlertType that will be used to configure the alert.
+ * @param message   The message (aka. informative text) that will be shown in the alert.
+ */
++(void)showAlertOfType:(VMMAlertType)alertType withMessage:(NSString*)message;
+
+/*!
+ * @discussion  Shows a VMMAlert with a title, an informative text, any other configurations specified in the block and an Ok button.
+ * @discussion  This method is thread safe, so it can be used from any thread or queue.
+ * @param title           The title that will be shown in the alert.
+ * @param message         The message (aka. informative text) that will be shown in the alert.
+ * @param optionsForAlert The block to make any extra adjustments in the alert before showing it.
+ */
++(void)showAlertWithTitle:(NSString*)title message:(NSString*)message andSettings:(void (^)(VMMAlert* alert))optionsForAlert;
+
+/*!
+ * @discussion  Shows a VMMAlert with a title, a subtitle, an attributed informative text and an Ok button.
+ * @discussion  This method is thread safe, so it can be used from any thread or queue.
+ * @param title           The title that will be shown in the alert.
+ * @param subtitle        The subtitle (aka. informative text) that will be shown in the alert.
+ * @param message         The message (aka. attributed informative text) that will be shown in the alert.
+ * @param fixedWidth      The width of the message area that will be shown in the alert (0 to use the real message width).
+ */
++(void)showAlertWithTitle:(NSString*)title subtitle:(NSString*)subtitle andAttributedMessage:(NSAttributedString*)message withWidth:(CGFloat)fixedWidth;
+
+/*!
+ * @discussion  Shows a VMMAlert with a title, an informative text and Yes/No buttons.
+ * @discussion  This method is thread safe, so it can be used from any thread or queue.
+ * @param title     The title that will be shown in the alert.
+ * @param message   The message (aka. informative text) that will be shown in the alert.
+ * @param highlight The button that will be highlighted by default in the alert (Yes/No).
+ * @return          true if Yes was pressed, false if No was pressed.
+ */
++(BOOL)showBooleanAlertWithTitle:(NSString*)title message:(NSString*)message highlighting:(BOOL)highlight;
+
+/*!
+ * @discussion  Shows a VMMAlert with a predefined VMMAlertType, an informative text and Yes/No buttons.
+ * @discussion  This method is thread safe, so it can be used from any thread or queue.
+ * @param alertType The VMMAlertType that will be used to configure the alert.
+ * @param message   The message (aka. informative text) that will be shown in the alert.
+ * @param highlight The button that will be highlighted by default in the alert (Yes/No).
+ * @return          true if Yes was pressed, false if No was pressed.
+ */
++(BOOL)showBooleanAlertOfType:(VMMAlertType)alertType withMessage:(NSString*)message highlighting:(BOOL)highlight;
+
+/*!
+ * @discussion  Shows a VMMAlert with a title, an informative text, any other configurations specified in the block and Yes/No buttons.
+ * @discussion  This method is thread safe, so it can be used from any thread or queue.
+ * @param title           The title that will be shown in the alert.
+ * @param message         The message (aka. informative text) that will be shown in the alert.
+ * @param highlight       The button that will be highlighted by default in the alert (Yes/No).
+ * @param optionsForAlert The block to make any extra adjustments in the alert before showing it.
+ * @return                true if Yes was pressed, false if No was pressed.
+ */
++(BOOL)showBooleanAlertWithTitle:(NSString*)title message:(NSString*)message highlighting:(BOOL)highlight withSettings:(void (^)(VMMAlert* alert))optionsForAlert;
+
+/*!
+ * @discussion  Shows a VMMAlert with a title, an informative text, any other configurations specified in the block and Ok/Cancel buttons.
+ * @discussion  This method is thread safe, so it can be used from any thread or queue.
+ * @param message         The message (aka. informative text) that will be shown in the alert.
+ * @param prompt          The title that will be shown in the alert.
+ * @param optionsForAlert The block to make any extra adjustments in the alert before showing it.
+ * @return                true if Ok was pressed, false if Cancel was pressed.
+ */
++(BOOL)confirmationDialogWithTitle:(NSString*)prompt message:(NSString*)message andSettings:(void (^)(VMMAlert* alert))optionsForAlert;
+
+/*!
+ * @discussion  Shows a VMMAlert with a title, an informative text, a text field and Ok/Cancel buttons.
+ * @discussion  This method is thread safe, so it can be used from any thread or queue.
+ * @param prompt       The title that will be shown in the alert.
+ * @param message      The message (aka. informative text) that will be shown in the alert.
+ * @param defaultValue The initial string value of the text field.
+ * @return             The string value of the text field if Ok was pressed, nil if Cancel was pressed.
+ */
++(NSString*)inputDialogWithTitle:(NSString*)prompt message:(NSString*)message defaultValue:(NSString*)defaultValue;
+
+/*!
+ * @discussion  Shows a VMMAlert with a title, an informative text, big squared buttons and a Cancel button.
+ * @discussion  This method is thread safe, so it can be used from any thread or queue.
+ * @param title         The title that will be shown in the alert.
+ * @param message       The message (aka. informative text) that will be shown in the alert.
+ * @param options       The list of the buttons that should appear in the dialog.
+ * @param iconForOption A block that needs as return the image that will be the icon for each button title.
+ * @return              The title of the pressed big button if any was pressed, nil if Cancel was pressed.
+ */
++(NSString*)showAlertWithTitle:(NSString*)title message:(NSString*)message buttonOptions:(NSArray<NSString*>*)options andIconForEachOption:(NSImage* (^)(NSString* option))iconForOption;
+
+@end
+
+#endif

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMAlert.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMAlert.m
@@ -1,0 +1,555 @@
+//
+//  VMMAlert.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+//  Reference for runModalWithWindow:
+//  https://github.com/adobe/brackets-app/blob/master/src/mac/cefclient/NSAlert%2BSynchronousSheet.m
+
+#import "VMMAlert.h"
+
+#import "NSApplication+Extension.h"
+#import "NSBundle+Extension.h"
+#import "NSThread+Extension.h"
+#import "NSMutableAttributedString+Extension.h"
+
+#import "VMMLogUtility.h"
+#import "VMMModals.h"
+#import "VMMLocalizationUtility.h"
+
+#define ALERT_WITH_ATTRIBUTED_MESSAGE_PARAGRAPH_SPACING  2.0f
+#define ALERT_WITH_ATTRIBUTED_MESSAGE_WIDTH_MARGIN       50
+#define ALERT_WITH_ATTRIBUTED_MESSAGE_WIDTH_LIMIT_MARGIN 200
+
+#define ALERT_WITH_BUTTON_OPTIONS_BUTTONS_LATERAL       0
+#define ALERT_WITH_BUTTON_OPTIONS_BUTTONS_SPACE         10
+#define ALERT_WITH_BUTTON_OPTIONS_ICON_WIDTH            80
+#define ALERT_WITH_BUTTON_OPTIONS_ICON_HEIGHT           80
+#define ALERT_WITH_BUTTON_OPTIONS_ICON_BORDER_WITH_TEXT 30
+#define ALERT_WITH_BUTTON_OPTIONS_ICON_BORDER           10
+#define ALERT_WITH_BUTTON_OPTIONS_ICON_IMAGE_BORDER     10
+#define ALERT_WITH_BUTTON_OPTIONS_ICONS_AT_X            3
+
+#define ALERT_WITH_BUTTON_OPTIONS_WINDOW_MIN_X_MARGIN   105
+#define ALERT_WITH_BUTTON_OPTIONS_WINDOW_MAX_X_MARGIN   18
+#define ALERT_WITH_BUTTON_OPTIONS_WINDOW_X_EXTRA_MARGIN 40
+
+#define INPUT_DIALOG_MESSAGE_FIELD_FRAME NSMakeRect(0, 0, 260, 24)
+
+#define ALERT_ICON_SIZE 512
+
+@interface NSImage (VMMImageForAlert)
+@end
+
+@implementation NSImage (VMMImageForAlert)
+-(NSImage*)getTintedImageWithColor:(NSColor*)color
+{
+    NSImage* tinted;
+    
+    @autoreleasepool
+    {
+        tinted = [[NSImage alloc] initWithSize:self.size];
+        [tinted lockFocus];
+        
+        NSRect imageRect = NSMakeRect(0, 0, self.size.width, self.size.height);
+        [self drawInRect:imageRect fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0];
+        
+        [color set];
+        NSRectFillUsingOperation(imageRect, NSCompositeSourceAtop);
+        
+        [tinted unlockFocus];
+    }
+    
+    return tinted;
+}
++(NSImage*)stopProgressIcon
+{
+    NSImage* icon = [NSImage imageNamed:NSImageNameStopProgressFreestandingTemplate];
+    [icon setSize:NSMakeSize(ALERT_ICON_SIZE, ALERT_ICON_SIZE)];
+    return [icon getTintedImageWithColor:[NSColor redColor]];
+}
++(NSImage*)cautionIcon
+{
+    NSImage* icon = [NSImage imageNamed:NSImageNameCaution];
+    [icon setSize:NSMakeSize(ALERT_ICON_SIZE, ALERT_ICON_SIZE)];
+    return icon;
+}
+@end
+
+@implementation VMMAlert
+
++(NSString*)titleForAlertType:(VMMAlertType)alertType
+{
+    switch (alertType)
+    {
+        case VMMAlertTypeSuccess:
+            return VMMLocalizedString(@"Success");
+            
+        case VMMAlertTypeWarning:
+            return VMMLocalizedString(@"Warning");
+            
+        case VMMAlertTypeError:
+            return VMMLocalizedString(@"Error");
+            
+        case VMMAlertTypeCritical:
+            return VMMLocalizedString(@"Error");
+            
+        case VMMAlertTypeCustom:
+        default: break;
+    }
+    
+    return [[NSBundle mainBundle] bundleName];
+}
+-(void)setIconWithAlertType:(VMMAlertType)alertType
+{
+    switch (alertType)
+    {
+        case VMMAlertTypeWarning:
+            [self setAlertStyle:NSCriticalAlertStyle];
+            break;
+            
+        case VMMAlertTypeError:
+            [self setIcon:[NSImage cautionIcon]];
+            break;
+            
+        case VMMAlertTypeCritical:
+            [self setIcon:[NSImage stopProgressIcon]];
+            break;
+            
+        default: break;
+    }
+}
+
+-(IBAction)BE_stopSynchronousSheet:(id)sender
+{
+    NSUInteger clickedButtonIndex = [[self buttons] indexOfObject:sender];
+    NSInteger modalCode = NSAlertFirstButtonReturn + clickedButtonIndex;
+    [NSApp stopModalWithCode:modalCode];
+}
+-(void)BE_beginSheetModalForWindow:(NSWindow *)aWindow
+{
+    [self beginSheetModalForWindow:aWindow modalDelegate:nil didEndSelector:nil contextInfo:nil];
+}
+-(NSUInteger)runModalWithWindow
+{
+    NSWindow* window = [VMMModals modalsWindow];
+    NSInteger modalCode;
+    
+    if (window != nil)
+    {
+        for (NSButton *button in self.buttons)
+        {
+            [button setTarget:self];
+            [button setAction:@selector(BE_stopSynchronousSheet:)];
+        }
+        
+        [self performSelectorOnMainThread:@selector(BE_beginSheetModalForWindow:) withObject:window waitUntilDone:YES];
+        
+        modalCode = [NSApp runModalForWindow:[self window]];
+        
+        [NSApp performSelectorOnMainThread:@selector(endSheet:) withObject:[self window] waitUntilDone:YES];
+        [[self window] performSelectorOnMainThread:@selector(orderOut:) withObject:self waitUntilDone:YES];
+        
+        return modalCode;
+    }
+    else
+    {
+        modalCode = [self runModal];
+    }
+    
+    switch (modalCode)
+    {
+        case -1000: // NSModalResponseStop
+        case -1001: // NSModalResponseAbort
+        case 0:     // NSModalResponseCancel
+            
+            // Selecting last button, which is supposed to be the Cancel button, or a Ok button in a single button dialog
+            modalCode = NSAlertFirstButtonReturn + ((self.buttons.count > 0) ? (self.buttons.count - 1) : 0);
+            break;
+            
+        case 1:     // NSModalResponseOK
+            
+            // Selecting first button, which is supposed to be the confirmation button, or a Ok button in a single button dialog
+            modalCode = NSAlertFirstButtonReturn;
+            break;
+            
+        default:
+            break;
+    }
+    
+    return modalCode;
+}
+
+-(NSUInteger)runThreadSafeModal
+{
+    return [VMMAlert runThreadSafeModalWithAlert:^VMMAlert*
+    {
+        return self;
+    }];
+}
++(NSUInteger)runThreadSafeModalWithAlert:(VMMAlert* (^)(void))alert
+{
+    if ([NSThread isMainThread])
+    {
+        return [alert() runModalWithWindow];
+    }
+    
+    NSCondition* lock = [[NSCondition alloc] init];
+    __block NSUInteger value;
+    
+    [NSThread dispatchBlockInMainQueue:^
+    {
+        value = [alert() runModalWithWindow];
+        
+        [lock signal];
+    }];
+    
+    [lock lock];
+    [lock wait];
+    [lock unlock];
+    
+    return value;
+}
+
++(void)showErrorAlertWithException:(NSException*)exception
+{
+    [self showAlertOfType:VMMAlertTypeError withMessage:[NSString stringWithFormat:@"%@: %@", exception.name, exception.reason]];
+}
++(void)showAlertOfType:(VMMAlertType)alertType withMessage:(NSString*)message
+{
+    @autoreleasepool
+    {
+        NSString* alertTitle = [self titleForAlertType:alertType];
+        
+        [self showAlertWithTitle:alertTitle message:message andSettings:^(VMMAlert* alert)
+        {
+            [alert setIconWithAlertType:alertType];
+        }];
+    }
+}
++(void)showAlertWithTitle:(NSString*)title message:(NSString*)message andSettings:(void (^)(VMMAlert* alert))optionsForAlert
+{
+    [self runThreadSafeModalWithAlert:^VMMAlert *
+    {
+        VMMAlert* msgBox = [[VMMAlert alloc] init];
+        [msgBox setMessageText:title];
+        [msgBox addButtonWithTitle:VMMLocalizedString(@"OK")];
+        if (message != nil) [msgBox setInformativeText:message];
+        
+        if (optionsForAlert != nil) optionsForAlert(msgBox);
+        
+        return msgBox;
+    }];
+}
+
++(void)showAlertWithTitle:(NSString*)title subtitle:(NSString*)subtitle andAttributedMessage:(NSAttributedString*)message withWidth:(CGFloat)fixedWidth
+{
+    __block NSTextView* informativeText = [[NSTextView alloc] init];
+    [informativeText setBackgroundColor:[NSColor clearColor]];
+    [informativeText.textStorage setAttributedString:message];
+    [informativeText setEditable:false];
+    
+    NSMutableParagraphStyle *paragrapStyle = [[NSMutableParagraphStyle alloc] init];
+    [paragrapStyle setParagraphSpacing:ALERT_WITH_ATTRIBUTED_MESSAGE_PARAGRAPH_SPACING];
+    [informativeText.textStorage addAttribute:NSParagraphStyleAttributeName value:paragrapStyle];
+    
+    CGFloat width = fixedWidth;
+    if (width < 0.01) {
+        width = informativeText.textStorage.size.width + ALERT_WITH_ATTRIBUTED_MESSAGE_WIDTH_MARGIN;
+    }
+    
+    CGFloat screenLimit = [[NSScreen mainScreen] visibleFrame].size.width - ALERT_WITH_ATTRIBUTED_MESSAGE_WIDTH_LIMIT_MARGIN;
+    if (width > screenLimit) width = screenLimit;
+    [informativeText setFrame:NSMakeRect(0, 0, width, informativeText.textStorage.size.height)];
+    
+    [self showAlertWithTitle:title message:subtitle andSettings:^(VMMAlert *alert)
+    {
+        [alert setAccessoryView:informativeText];
+    }];
+}
+
++(BOOL)showBooleanAlertWithTitle:(NSString*)title message:(NSString*)message highlighting:(BOOL)highlight
+{
+    BOOL result;
+    
+    @autoreleasepool
+    {
+        result = [self showBooleanAlertWithTitle:title message:message highlighting:highlight withSettings:^(VMMAlert* alert) {}];
+    }
+    
+    return result;
+}
++(BOOL)showBooleanAlertOfType:(VMMAlertType)alertType withMessage:(NSString*)message highlighting:(BOOL)highlight
+{
+    BOOL result;
+    
+    @autoreleasepool
+    {
+        NSString* alertTitle = [self titleForAlertType:alertType];
+        
+        result = [self showBooleanAlertWithTitle:alertTitle message:message highlighting:highlight withSettings:^(VMMAlert* alert)
+        {
+            [alert setIconWithAlertType:alertType];
+        }];
+    }
+    
+    return result;
+}
++(BOOL)showBooleanAlertWithTitle:(NSString*)title message:(NSString*)message highlighting:(BOOL)highlight withSettings:(void (^)(VMMAlert* alert))optionsForAlert
+{
+    BOOL value = !highlight;
+    NSString* defaultButton;
+    NSString* alternateButton;
+    
+    if (highlight)
+    {
+        defaultButton = VMMLocalizedString(@"Yes");
+        alternateButton = VMMLocalizedString(@"No");
+    }
+    else
+    {
+        defaultButton = VMMLocalizedString(@"No");
+        alternateButton = VMMLocalizedString(@"Yes");
+    }
+    
+    NSUInteger alertResult = [self runThreadSafeModalWithAlert:^VMMAlert *
+    {
+        VMMAlert* alert = [[VMMAlert alloc] init];
+        [alert setMessageText:title != nil ? title : @""];
+        [alert addButtonWithTitle:defaultButton];
+        [alert addButtonWithTitle:alternateButton];
+        [alert setInformativeText:message];
+        optionsForAlert(alert);
+        return alert;
+    }];
+    
+    if (alertResult == NSAlertFirstButtonReturn) value = highlight;
+    return value;
+}
+
++(BOOL)confirmationDialogWithTitle:(NSString*)prompt message:(NSString*)message andSettings:(void (^)(VMMAlert* alert))optionsForAlert
+{
+    NSUInteger alertResult;
+    
+    @autoreleasepool
+    {
+        alertResult = [self runThreadSafeModalWithAlert:^VMMAlert *
+        {
+            VMMAlert *alert = [[VMMAlert alloc] init];
+            [alert setMessageText:prompt];
+            [alert addButtonWithTitle:VMMLocalizedString(@"OK")];
+            [alert addButtonWithTitle:VMMLocalizedString(@"Cancel")];
+            [alert setInformativeText:message];
+            if (optionsForAlert != nil) optionsForAlert(alert);
+            return alert;
+        }];
+    }
+    
+    return alertResult == NSAlertFirstButtonReturn;
+}
+
++(NSString*)inputDialogWithTitle:(NSString*)prompt message:(NSString*)message defaultValue:(NSString*)defaultValue
+{
+    NSString* result;
+    
+    @autoreleasepool
+    {
+        if ([NSThread isMainThread])
+        {
+            VMMAlert *alert = [[VMMAlert alloc] init];
+            [alert setMessageText:prompt];
+            [alert addButtonWithTitle:VMMLocalizedString(@"OK")];
+            [alert addButtonWithTitle:VMMLocalizedString(@"Cancel")];
+            [alert setInformativeText:message];
+            
+            NSTextField *input = [[NSTextField alloc] initWithFrame:INPUT_DIALOG_MESSAGE_FIELD_FRAME];
+            if (defaultValue != nil) [input setStringValue:defaultValue];
+            [alert setAccessoryView:input];
+            [[alert window] setInitialFirstResponder:input];
+            
+            if ([alert runModalWithWindow] == NSAlertFirstButtonReturn)
+            {
+                [input validateEditing];
+                result = [input stringValue];
+            }
+        }
+        else
+        {
+            NSCondition* lock = [[NSCondition alloc] init];
+            __block NSString* value = nil;
+            [NSThread dispatchBlockInMainQueue:^
+             {
+                 VMMAlert *alert = [[VMMAlert alloc] init];
+                 [alert setMessageText:prompt];
+                 [alert addButtonWithTitle:VMMLocalizedString(@"OK")];
+                 [alert addButtonWithTitle:VMMLocalizedString(@"Cancel")];
+                 [alert setInformativeText:message];
+                 
+                 NSTextField *input = [[NSTextField alloc] initWithFrame:INPUT_DIALOG_MESSAGE_FIELD_FRAME];
+                 if (defaultValue != nil) [input setStringValue:defaultValue];
+                 [alert setAccessoryView:input];
+                 [[alert window] setInitialFirstResponder:input];
+                 
+                 if ([alert runModalWithWindow] == NSAlertFirstButtonReturn)
+                 {
+                     [input validateEditing];
+                     value = [input stringValue];
+                 }
+                 [lock signal];
+             }];
+            [lock lock];
+            [lock wait];
+            [lock unlock];
+            
+            result = value;
+        }
+    }
+    
+    return result;
+}
+
+static VMMAlert* _alertWithButtonOptions;
++(void)selectAlertButton:(NSButton*)sender
+{
+    sender.tag = true;
+    
+    [[_alertWithButtonOptions window] setIsVisible:NO]; // will make it invisible instantly
+    [NSApp endSheet:[_alertWithButtonOptions window]];  // will close it after the next dialog
+}
++(NSString*)showAlertWithTitle:(NSString*)title message:(NSString*)message buttonOptions:(NSArray<NSString*>*)options andIconForEachOption:(NSImage* (^)(NSString* option))iconForOption
+{
+    if (IS_SYSTEM_MAC_OS_10_15_OR_SUPERIOR) {
+        NSUInteger alertResult = [VMMAlert runThreadSafeModalWithAlert:^VMMAlert *
+          {
+              VMMAlert *alert = [[VMMAlert alloc] init];
+              [alert setMessageText:title];
+              [alert setInformativeText:message];
+              
+              for (NSString* button in options) {
+                    [alert addButtonWithTitle:button];
+              }
+              [alert addButtonWithTitle:VMMLocalizedString(@"Cancel")];
+              
+              return alert;
+          }] - NSAlertFirstButtonReturn;
+        if (options.count == alertResult) {
+            return nil;
+        }
+        return [options objectAtIndex:alertResult];
+    }
+    
+    NSString* result = nil;
+    
+    @autoreleasepool
+    {
+        int totalY = (int) ((options.count-1) / ALERT_WITH_BUTTON_OPTIONS_ICONS_AT_X) + 1;
+        int totalX = (int) ((ALERT_WITH_BUTTON_OPTIONS_ICONS_AT_X > options.count) ? options.count : ALERT_WITH_BUTTON_OPTIONS_ICONS_AT_X);
+        BOOL hasSingleLine = totalX == options.count;
+        
+        CGFloat iconHeight = ALERT_WITH_BUTTON_OPTIONS_ICON_HEIGHT;
+        CGFloat iconWidth  = ALERT_WITH_BUTTON_OPTIONS_ICON_WIDTH;
+        
+        CGFloat viewHeight = iconHeight*totalY + (totalY-1)*ALERT_WITH_BUTTON_OPTIONS_BUTTONS_SPACE;
+        CGFloat viewWidth = ALERT_WITH_BUTTON_OPTIONS_BUTTONS_LATERAL*2 + iconWidth*ALERT_WITH_BUTTON_OPTIONS_ICONS_AT_X +
+                            (ALERT_WITH_BUTTON_OPTIONS_ICONS_AT_X-1)*ALERT_WITH_BUTTON_OPTIONS_BUTTONS_SPACE;
+        
+        __block NSView* sourcesView = [[NSView alloc] init];
+        [sourcesView setFrame:NSMakeRect(0, 0, viewWidth,viewHeight)];
+        [sourcesView setAutoresizingMask:NSViewMaxXMargin|NSViewMinXMargin];
+        
+        for (int i = 0; i < options.count; i++)
+        {
+            int x = i % ALERT_WITH_BUTTON_OPTIONS_ICONS_AT_X;
+            int y = i / ALERT_WITH_BUTTON_OPTIONS_ICONS_AT_X;
+            
+            BOOL isLastLine = (y + 1 == totalY);
+            int totalXLine = (!isLastLine || hasSingleLine) ? (totalX) : (options.count % totalX);
+            
+            CGFloat axisX = viewWidth/2 - totalXLine*iconWidth/2 + x*iconWidth +
+                            ((1-(totalXLine-2*x))/2.0)*ALERT_WITH_BUTTON_OPTIONS_BUTTONS_SPACE;
+            CGFloat axisY = (iconHeight + ALERT_WITH_BUTTON_OPTIONS_BUTTONS_SPACE)*(totalY - y - 1);
+            
+            NSButton* button = [[NSButton alloc] initWithFrame:NSMakeRect(axisX,axisY,iconWidth,iconHeight)];
+            
+            NSString* sourceName = options[i];
+            NSImage* icon = iconForOption(sourceName);
+            BOOL doesNotHaveValidIcon = (icon == nil);
+            
+            button.tag = false;
+            
+            [button setTitle:sourceName];
+            NSMutableAttributedString* title = [[button attributedTitle] mutableCopy];
+            [title adjustExpansionToFitWidth:iconWidth - 10];
+            [button setAttributedTitle:title];
+            
+            CGFloat iconBorder;
+            if (doesNotHaveValidIcon)
+            {
+                [button setBordered:YES];
+                [button setImagePosition:NSNoImage];
+                iconBorder = ALERT_WITH_BUTTON_OPTIONS_ICON_BORDER_WITH_TEXT;
+            }
+            else
+            {
+                [button setBordered:NO];
+                [button setImagePosition:NSImageOnly];
+                iconBorder = ALERT_WITH_BUTTON_OPTIONS_ICON_BORDER;
+            }
+            
+            NSImage* resultImage;
+            
+            if (icon != nil)
+            {
+                resultImage = [[NSImage alloc] initWithSize:NSMakeSize(iconWidth, iconHeight)];
+                [resultImage lockFocus];
+                
+                NSRect newRect = NSMakeRect(ALERT_WITH_BUTTON_OPTIONS_ICON_IMAGE_BORDER/2, ALERT_WITH_BUTTON_OPTIONS_ICON_IMAGE_BORDER/2,
+                                            iconWidth - ALERT_WITH_BUTTON_OPTIONS_ICON_IMAGE_BORDER,
+                                            iconHeight - ALERT_WITH_BUTTON_OPTIONS_ICON_IMAGE_BORDER);
+                [icon drawInRect:newRect fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0];
+                
+                [resultImage unlockFocus];
+                [resultImage setSize:NSMakeSize(iconWidth - iconBorder, iconHeight - iconBorder)];
+                [button setImage:resultImage];
+            }
+            
+            [button setTarget:self];
+            [button setAction:@selector(selectAlertButton:)];
+            
+            [sourcesView addSubview:button];
+        }
+        
+        [self runThreadSafeModalWithAlert:^VMMAlert *
+        {
+            _alertWithButtonOptions = [[VMMAlert alloc] init];
+            [_alertWithButtonOptions setMessageText:title];
+            [_alertWithButtonOptions addButtonWithTitle:VMMLocalizedString(@"Cancel")];
+            [_alertWithButtonOptions setInformativeText:message];
+            
+            CGFloat properWidth = _alertWithButtonOptions.window.frame.size.width - ALERT_WITH_BUTTON_OPTIONS_WINDOW_MIN_X_MARGIN - ALERT_WITH_BUTTON_OPTIONS_WINDOW_MAX_X_MARGIN - ALERT_WITH_BUTTON_OPTIONS_WINDOW_X_EXTRA_MARGIN;
+            
+            NSView* accessoryView = [[NSView alloc] init];
+            [accessoryView setAutoresizingMask:NSViewWidthSizable];
+            [accessoryView setFrameSize:NSMakeSize(viewWidth,viewHeight)];
+            [accessoryView addSubview:sourcesView];
+            [accessoryView setFrameSize:NSMakeSize(properWidth,viewHeight)];
+            [_alertWithButtonOptions setAccessoryView:accessoryView];
+            
+            return _alertWithButtonOptions;
+        }];
+        
+        for (NSButton* button in sourcesView.subviews)
+        {
+            if (button.tag == true) result = [button title];
+        }
+        
+        _alertWithButtonOptions = nil;
+    }
+    
+    return result;
+}
+
+@end
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMComputerInformation.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMComputerInformation.h
@@ -1,0 +1,336 @@
+//
+//  VMMComputerInformation.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+//  System requirements references:
+//  https://developer.apple.com/library/content/releasenotes/MacOSX/WhatsNewInOSX/Articles/MacOSX10_7.html
+//  https://developer.apple.com/library/content/releasenotes/MacOSX/WhatsNewInOSX/Articles/MacOSX10_8.html
+//  https://developer.apple.com/library/content/releasenotes/MacOSX/WhatsNewInOSX/Articles/MacOSX10_9.html
+//  https://developer.apple.com/library/content/releasenotes/MacOSX/WhatsNewInOSX/Articles/MacOSX10_10.html
+//  https://developer.apple.com/library/content/releasenotes/MacOSX/WhatsNewInOSX/Articles/MacOSX10_11.html
+//  https://developer.apple.com/library/content/releasenotes/MacOSX/WhatsNewInOSX/Articles/OSXv10.html
+//  https://developer.apple.com/library/content/releasenotes/MacOSX/WhatsNewInOSX/Articles/macOS_10_13_0.html
+//
+//  User groups references:
+//  https://apple.stackexchange.com/a/240281
+//  dscl . list /Groups PrimaryGroupID | tr -s ' ' | sort -n -t ' ' -k2,2
+//
+
+#ifndef VMMComputerInformation_Class
+#define VMMComputerInformation_Class
+
+// Checks if macOS version is compatible
+#define IS_SYSTEM_MAC_OS_10_7_OR_SUPERIOR   [VMMComputerInformation isSystemMacOsEqualOrSuperiorTo:@"10.7"]   // Lion
+#define IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR   [VMMComputerInformation isSystemMacOsEqualOrSuperiorTo:@"10.8"]   // Mountain Lion
+#define IS_SYSTEM_MAC_OS_10_9_OR_SUPERIOR   [VMMComputerInformation isSystemMacOsEqualOrSuperiorTo:@"10.9"]   // Mavericks
+#define IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR  [VMMComputerInformation isSystemMacOsEqualOrSuperiorTo:@"10.10"]  // Yosemite
+#define IS_SYSTEM_MAC_OS_10_11_OR_SUPERIOR  [VMMComputerInformation isSystemMacOsEqualOrSuperiorTo:@"10.11"]  // El Capitan
+#define IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR  [VMMComputerInformation isSystemMacOsEqualOrSuperiorTo:@"10.12"]  // Sierra
+#define IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR  [VMMComputerInformation isSystemMacOsEqualOrSuperiorTo:@"10.13"]  // High Sierra
+#define IS_SYSTEM_MAC_OS_10_14_OR_SUPERIOR  [VMMComputerInformation isSystemMacOsEqualOrSuperiorTo:@"10.14"]  // Mojave
+#define IS_SYSTEM_MAC_OS_10_15_OR_SUPERIOR  [VMMComputerInformation isSystemMacOsEqualOrSuperiorTo:@"10.15"]  // Catalina
+#define IS_SYSTEM_MAC_OS_11_0_OR_SUPERIOR   [VMMComputerInformation isSystemMacOsEqualOrSuperiorTo:@"11.0"]   // Big Sur
+
+#define IS_SYSTEM_MAC_OS_LION_OR_SUPERIOR           IS_SYSTEM_MAC_OS_10_7_OR_SUPERIOR
+#define IS_SYSTEM_MAC_OS_MOUNTAIN_LION_OR_SUPERIOR  IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IS_SYSTEM_MAC_OS_MAVERICKS_OR_SUPERIOR      IS_SYSTEM_MAC_OS_10_9_OR_SUPERIOR
+#define IS_SYSTEM_MAC_OS_YOSEMITE_OR_SUPERIOR       IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IS_SYSTEM_MAC_OS_EL_CAPITAN_OR_SUPERIOR     IS_SYSTEM_MAC_OS_10_11_OR_SUPERIOR
+#define IS_SYSTEM_MAC_OS_SIERRA_OR_SUPERIOR         IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IS_SYSTEM_MAC_OS_HIGH_SIERRA_OR_SUPERIOR    IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IS_SYSTEM_MAC_OS_MOJAVE_OR_SUPERIOR         IS_SYSTEM_MAC_OS_10_14_OR_SUPERIOR
+#define IS_SYSTEM_MAC_OS_CATALINA_OR_SUPERIOR       IS_SYSTEM_MAC_OS_10_15_OR_SUPERIOR
+#define IS_SYSTEM_MAC_OS_BIG_SUR_OR_SUPERIOR        IS_SYSTEM_MAC_OS_11_0_OR_SUPERIOR
+
+
+// Checks if deprecated frameworks are still available
+#define IsFrameworkMessageAvailable                     (!IS_SYSTEM_MAC_OS_10_9_OR_SUPERIOR)
+#define IsFrameworkServerNotificationAvailable          (!IS_SYSTEM_MAC_OS_10_9_OR_SUPERIOR)
+#define IsFrameworkAppleShareClientCoreAvailable        (!IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR)
+#define IsFrameworkRubyCocoaAvailable                   (!IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR)
+#define IsFrameworkSharedFileListAvailable              (!IS_SYSTEM_MAC_OS_10_11_OR_SUPERIOR)
+#define IsFrameworkVideoDecodeAccelerationAvailable     (!IS_SYSTEM_MAC_OS_10_11_OR_SUPERIOR)
+
+
+// Checks if deprecated classes are still available
+#define IsClassNSGarbageCollectorAvailable              (!IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR)
+
+
+// Checks if new frameworks are available
+#define IsFrameworkAVFoundationAvailable                IS_SYSTEM_MAC_OS_10_7_OR_SUPERIOR
+
+#define IsFrameworkAccountsAvailable                    IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsFrameworkAudioVideoBridgingAvailable          IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsFrameworkEventKitAvailable                    IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsFrameworkGameKitAvailable                     IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsFrameworkGLKitAvailable                       IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsFrameworkSceneKitAvailable                    IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsFrameworkSocialAvailable                      IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsFrameworkVideoToolboxAvailable                IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+
+#define IsFrameworkAVKitAvailable                       IS_SYSTEM_MAC_OS_10_9_OR_SUPERIOR
+#define IsFrameworkSpriteKitAvailable                   IS_SYSTEM_MAC_OS_10_9_OR_SUPERIOR
+#define IsFrameworkMapKitAvailable                      IS_SYSTEM_MAC_OS_10_9_OR_SUPERIOR
+#define IsFrameworkGameControllerAvailable              IS_SYSTEM_MAC_OS_10_9_OR_SUPERIOR
+#define IsFrameworkMediaAccessibilityAvailable          IS_SYSTEM_MAC_OS_10_9_OR_SUPERIOR
+#define IsFrameworkMediaLibraryAvailable                IS_SYSTEM_MAC_OS_10_9_OR_SUPERIOR
+#define IsFrameworkiTunesLibraryAvailable               IS_SYSTEM_MAC_OS_10_9_OR_SUPERIOR
+
+#define IsFrameworkCryptoTokenKitAvailable              IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsFrameworkFinderSyncAvailable                  IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsFrameworkHypervisorAvailable                  IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsFrameworkMultipeerConnectivityAvailable       IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsFrameworkNotificationCenterAvailable          IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+
+#define IsFrameworkContactsAvailable                    IS_SYSTEM_MAC_OS_10_11_OR_SUPERIOR
+#define IsFrameworkGameplayKitAvailable                 IS_SYSTEM_MAC_OS_10_11_OR_SUPERIOR
+#define IsFrameworkMetalAvailable                       IS_SYSTEM_MAC_OS_10_11_OR_SUPERIOR
+#define IsFrameworkMetalKitAvailable                    IS_SYSTEM_MAC_OS_10_11_OR_SUPERIOR
+#define IsFrameworkModelIOAvailable                     IS_SYSTEM_MAC_OS_10_11_OR_SUPERIOR
+#define IsFrameworkNetworkExtensionAvailable            IS_SYSTEM_MAC_OS_10_11_OR_SUPERIOR
+
+#define IsFrameworkIntentsAvailable                     IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsFrameworkSafariServicesAvailable              IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+
+#define IsFrameworkCoreMLAvailable                      IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IsFrameworkVisionAvailable                      IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+
+#define IsFrameworkOpenGLAvailable                      !IS_SYSTEM_MAC_OS_10_14_OR_SUPERIOR
+
+
+// Checks if new classes are available
+#define IsClassNSDraggingImageComponentAvailable        IS_SYSTEM_MAC_OS_10_7_OR_SUPERIOR
+#define IsClassNSDraggingItemAvailable                  IS_SYSTEM_MAC_OS_10_7_OR_SUPERIOR
+#define IsClassNSDraggingSessionAvailable               IS_SYSTEM_MAC_OS_10_7_OR_SUPERIOR
+#define IsClassNSFontCollectionAvailable                IS_SYSTEM_MAC_OS_10_7_OR_SUPERIOR
+#define IsClassNSJSONSerializationAvailable             IS_SYSTEM_MAC_OS_10_7_OR_SUPERIOR
+#define IsClassNSLinguisticTaggerAvailable              IS_SYSTEM_MAC_OS_10_7_OR_SUPERIOR
+#define IsClassNSOrderedSetAvailable                    IS_SYSTEM_MAC_OS_10_7_OR_SUPERIOR
+#define IsClassNSRegularExpressionAvailable             IS_SYSTEM_MAC_OS_10_7_OR_SUPERIOR
+
+#define IsClassAVPlayerItemOutputAvailable              IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsClassAVSampleBufferDisplayLayerAvailable      IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsClassCLGeocoderAvailable                      IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsClassCLPlacemarkAvailable                     IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsClassCMClockAvailable                         IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsClassCMTimebaseAvailable                      IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsClassNSPageControllerAvailable                IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsClassNSTextAlternativesAvailable              IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsClassNSUserNotificationCenterAvailable        IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsClassNSUUIDAvailable                          IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsClassNSXPCConnectionAvailable                 IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsClassSKDownloadAvailable                      IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+#define IsClassSKPaymentQueueAvailable                  IS_SYSTEM_MAC_OS_10_8_OR_SUPERIOR
+
+#define IsClassNSMediaLibraryBrowserControllerAvailable IS_SYSTEM_MAC_OS_10_9_OR_SUPERIOR
+#define IsClassNSStackViewAvailable                     IS_SYSTEM_MAC_OS_10_9_OR_SUPERIOR
+#define IsClassNSProgressAvailable                      IS_SYSTEM_MAC_OS_10_9_OR_SUPERIOR
+#define IsClassNSURLSessionAvailable                    IS_SYSTEM_MAC_OS_10_9_OR_SUPERIOR
+
+#define IsClassGKSavedGameAvailable                     IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsClassNSDateComponentsFormatterAvailable       IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsClassNSDateIntervalFormatterAvailable         IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsClassNSEnergyFormatterAvailable               IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsClassNSGestureRecognizerAvailable             IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsClassNSLengthFormatterAvailable               IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsClassNSMassFormatterAvailable                 IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsClassNSSplitViewItemAvailable                 IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsClassNSVisualEffectViewAvailable              IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsClassSCNActionAvailable                       IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsClassSCNParticleSystemAvailable               IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsClassSCNPhysicsBehaviorAvailable              IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsClassSCNPhysicsFieldAvailable                 IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsClassSCNPhysicsVehicleAvailable               IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsClassSCNPhysicsWorldAvailable                 IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsClassSCNTechniqueAvailable                    IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+#define IsClassWKWebViewAvailable                       IS_SYSTEM_MAC_OS_10_10_OR_SUPERIOR
+
+#define IsClassNSLayoutGuideAvailable                   IS_SYSTEM_MAC_OS_10_11_OR_SUPERIOR
+#define IsClassNSPersonNameComponentsFormatterAvailable IS_SYSTEM_MAC_OS_10_11_OR_SUPERIOR
+#define IsClassSCNAudioPlayerAvailable                  IS_SYSTEM_MAC_OS_10_11_OR_SUPERIOR
+
+#define IsClassAVAssetCacheAvailable                    IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassAVPlayerLooperAvailable                  IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassGKCloudPlayerAvailable                   IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassGKDecisionNodeAvailable                  IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassGKDecisionTreeAvailable                  IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassGKGameSessionAvailable                   IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassGKGraphNode3DAvailable                   IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassGKMeshGraphAvailable                     IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassGKMonteCarloStrategistAvailable          IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassGKSceneAvailable                         IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassGKSKNodeComponentAvailable               IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassMDLMaterialPropertyGraphAvailable        IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassNSDateIntervalAvailable                  IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassNSDimensionAvailable                     IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassNSISO8601DateFormatterAvailable          IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassNSPersistentContainerAvailable           IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassNSURLSessionTaskMetricsAvailable         IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassPHLivePhotoAvailable                     IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassPHLivePhotoEditingContextAvailable       IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassPHLivePhotoViewAvailable                 IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassSKTileGroupAvailable                     IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassSKTileGroupRuleAvailable                 IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassSKTileMapNodeAvailable                   IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassSKTileSetAvailable                       IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+#define IsClassSKWarpGeometryAvailable                  IS_SYSTEM_MAC_OS_10_12_OR_SUPERIOR
+
+#define IsClassCIBarcodeDescriptorAvailable             IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IsClassAVSampleBufferAudioRendererAvailable     IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IsClassCIBicubicScaleTransformAvailable         IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IsClassCIBlendKernelAvailable                   IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IsClassCIBokehBlurAvailable                     IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IsClassCIColorCurvesAvailable                   IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IsClassCILabDeltaEAvailable                     IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IsClassCIMinMaxRedAvailable                     IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IsClassCITextImageGeneratorAvailable            IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IsClassCIRenderDestinationAvailable             IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IsClassNSFontAssetRequestAvailable              IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IsClassPHAssetAvailable                         IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IsClassPHFetchRequestAvailable                  IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IsClassPHPhotoLibraryAvailable                  IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IsClassPHProjectAvailable                       IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IsClassPHProjectChangeRequestAvailable          IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+#define IsClassPHProjectInfoAvailable                   IS_SYSTEM_MAC_OS_10_13_OR_SUPERIOR
+
+#define IsClassNSTouchBarAvailable                      [VMMComputerInformation isSystemMacOsEqualOrSuperiorTo:@"10.12.2"]
+#define IsClassAVRouteDetectorAvailable                 [VMMComputerInformation isSystemMacOsEqualOrSuperiorTo:@"10.13.2"]
+
+
+#import <Foundation/Foundation.h>
+#import "ObjCExtensionConfig.h"
+
+static NSString* _Nonnull const SPAirPortDataType              = @"SPAirPortDataType";
+static NSString* _Nonnull const SPApplicationsDataType         = @"SPApplicationsDataType";
+static NSString* _Nonnull const SPAudioDataType                = @"SPAudioDataType";
+static NSString* _Nonnull const SPBluetoothDataType            = @"SPBluetoothDataType";
+static NSString* _Nonnull const SPCameraDataType               = @"SPCameraDataType";
+static NSString* _Nonnull const SPCardReaderDataType           = @"SPCardReaderDataType";
+static NSString* _Nonnull const SPComponentDataType            = @"SPComponentDataType";
+static NSString* _Nonnull const SPConfigurationProfileDataType = @"SPConfigurationProfileDataType";
+static NSString* _Nonnull const SPDeveloperToolsDataType       = @"SPDeveloperToolsDataType";
+static NSString* _Nonnull const SPDiagnosticsDataType          = @"SPDiagnosticsDataType";
+static NSString* _Nonnull const SPDisabledSoftwareDataType     = @"SPDisabledSoftwareDataType";
+static NSString* _Nonnull const SPDiscBurningDataType          = @"SPDiscBurningDataType";
+static NSString* _Nonnull const SPDisplaysDataType             = @"SPDisplaysDataType";
+static NSString* _Nonnull const SPEthernetDataType             = @"SPEthernetDataType";
+static NSString* _Nonnull const SPExtensionsDataType           = @"SPExtensionsDataType";
+static NSString* _Nonnull const SPFibreChannelDataType         = @"SPFibreChannelDataType";
+static NSString* _Nonnull const SPFirewallDataType             = @"SPFirewallDataType";
+static NSString* _Nonnull const SPFireWireDataType             = @"SPFireWireDataType";
+static NSString* _Nonnull const SPFontsDataType                = @"SPFontsDataType";
+static NSString* _Nonnull const SPFrameworksDataType           = @"SPFrameworksDataType";
+static NSString* _Nonnull const SPHardwareDataType             = @"SPHardwareDataType";
+static NSString* _Nonnull const SPHardwareRAIDDataType         = @"SPHardwareRAIDDataType";
+static NSString* _Nonnull const SPiBridgeDataType              = @"SPiBridgeDataType";
+static NSString* _Nonnull const SPInstallHistoryDataType       = @"SPInstallHistoryDataType";
+static NSString* _Nonnull const SPLogsDataType                 = @"SPLogsDataType";
+static NSString* _Nonnull const SPManagedClientDataType        = @"SPManagedClientDataType";
+static NSString* _Nonnull const SPMemoryDataType               = @"SPMemoryDataType";
+static NSString* _Nonnull const SPModemDataType                = @"SPModemDataType";
+static NSString* _Nonnull const SPNetworkDataType              = @"SPNetworkDataType";
+static NSString* _Nonnull const SPNetworkLocationDataType      = @"SPNetworkLocationDataType";
+static NSString* _Nonnull const SPNetworkVolumeDataType        = @"SPNetworkVolumeDataType";
+static NSString* _Nonnull const SPNVMeDataType                 = @"SPNVMeDataType";
+static NSString* _Nonnull const SPParallelATADataType          = @"SPParallelATADataType";
+static NSString* _Nonnull const SPParallelSCSIDataType         = @"SPParallelSCSIDataType";
+static NSString* _Nonnull const SPPCCardDataType               = @"SPPCCardDataType";
+static NSString* _Nonnull const SPPCIDataType                  = @"SPPCIDataType";
+static NSString* _Nonnull const SPPowerDataType                = @"SPPowerDataType";
+static NSString* _Nonnull const SPPrefPaneDataType             = @"SPPrefPaneDataType";
+static NSString* _Nonnull const SPPrintersDataType             = @"SPPrintersDataType";
+static NSString* _Nonnull const SPPrintersSoftwareDataType     = @"SPPrintersSoftwareDataType";
+static NSString* _Nonnull const SPRawCameraDataType            = @"SPRawCameraDataType";
+static NSString* _Nonnull const SPSASDataType                  = @"SPSASDataType";
+static NSString* _Nonnull const SPSerialATADataType            = @"SPSerialATADataType";
+static NSString* _Nonnull const SPSmartCardsDataType           = @"SPSmartCardsDataType";
+static NSString* _Nonnull const SPSoftwareDataType             = @"SPSoftwareDataType";
+static NSString* _Nonnull const SPSPIDataType                  = @"SPSPIDataType";
+static NSString* _Nonnull const SPStartupItemDataType          = @"SPStartupItemDataType";
+static NSString* _Nonnull const SPStorageDataType              = @"SPStorageDataType";
+static NSString* _Nonnull const SPSyncServicesDataType         = @"SPSyncServicesDataType";
+static NSString* _Nonnull const SPThunderboltDataType          = @"SPThunderboltDataType";
+static NSString* _Nonnull const SPUniversalAccessDataType      = @"SPUniversalAccessDataType";
+static NSString* _Nonnull const SPUSBDataType                  = @"SPUSBDataType";
+static NSString* _Nonnull const SPWWANDataType                 = @"SPWWANDataType";
+
+
+typedef enum VMMUserGroup
+{
+    VMMUserGroupEveryone      = 12,
+    VMMUserGroupStaff         = 20, // root
+    VMMUserGroupInteractUsers = 51,
+    VMMUserGroupNetUsers      = 52,
+    VMMUserGroupConsoleUsers  = 53,
+    VMMUserGroupLocalAccounts = 61,
+    VMMUserGroupNetAccounts   = 62,
+    VMMUserGroupAdmin         = 80, // Admin rights
+    VMMUserGroupAccessibility = 90,
+} VMMUserGroup;
+
+
+// Equivalents to their MTLFeatureSet_macOS_GPUFamily*_v* counterparts
+typedef NS_ENUM(NSUInteger, VMMMetalFeatureSet)
+{
+    VMMMetalFeatureSet_macOS_GPUFamilyNone    = 0,   // In case it has no Metal support
+    VMMMetalFeatureSet_macOS_GPUFamilyUnknown = 999, // In case it can't be deduced
+    
+    VMMMetalFeatureSet_macOS_GPUFamily1_v1 = 1000, // Introduced in macOS 10.11
+    VMMMetalFeatureSet_macOS_GPUFamily1_v2 = 1001, // Introduced in macOS 10.12
+    VMMMetalFeatureSet_macOS_GPUFamily1_v3 = 1003, // Introduced in macOS 10.13
+    VMMMetalFeatureSet_macOS_GPUFamily1_v4 = 1004, // Introduced in macOS 10.14
+    VMMMetalFeatureSet_macOS_GPUFamily2_v1 = 1005  // Introduced in macOS 10.14
+};
+// The first number defines the GPU family. The second one defines the macOS support version.
+// References:
+// https://developer.apple.com/documentation/metal/mtlfeatureset?language=objc
+// https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
+
+
+typedef NS_ENUM(NSUInteger, VMMExternalGPUCompatibilityWithMacOS)
+{
+    VMMExternalGPUCompatibilityWithMacOS_None      = 0,
+    VMMExternalGPUCompatibilityWithMacOS_MajorHack = 1,
+    VMMExternalGPUCompatibilityWithMacOS_MinorHack = 2,
+    VMMExternalGPUCompatibilityWithMacOS_Supported = 3
+};
+
+
+@interface VMMComputerInformation : NSObject
+
++(nullable NSArray<NSDictionary*>*)systemProfilerItemsForDataType:(nonnull NSString*)dataType;
+    
++(long long int)hardDiskSize;
++(long long int)hardDiskFreeSize;
++(long long int)hardDiskUsedSize;
++(long long int)ramMemorySize;
++(long long int)ramMemoryFreeSize;
++(long long int)ramMemoryUsedSize;
++(nullable NSString*)processorNameAndSpeed;
++(double)processorUsage;
++(nullable NSString*)macModel;
+
++(nullable NSString*)macOsVersion;
++(nullable NSString*)completeMacOsVersion;
++(BOOL)isSystemMacOsEqualOrSuperiorTo:(nonnull NSString*)version;
++(nullable NSString*)macOsBuildVersion;
+
++(BOOL)isUserMemberOfUserGroup:(VMMUserGroup)userGroup;
+
++(BOOL)isSipEnabled;
++(BOOL)are32bitProcessesEnabled;
+
++(nonnull NSArray*)metalDevices;
+
++(BOOL)isSystemIntegrityProtectionEnabled;
+
++(nonnull NSArray<NSDictionary*>*)thunderboltPorts;
+
++(VMMExternalGPUCompatibilityWithMacOS)macOsCompatibilityWithExternalGPU;
+
+@end
+
+#endif

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMComputerInformation.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMComputerInformation.m
@@ -1,0 +1,478 @@
+//
+//  VMMComputerInformation.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+//
+//  Obtaining VRAM with the API:
+//  https://gist.github.com/ScrimpyCat/8043890
+//
+
+#import "VMMComputerInformation.h"
+
+#import "VMMVersion.h"
+#import "VMMPropertyList.h"
+
+#import "NSTask+Extension.h"
+#import "NSArray+Extension.h"
+#import "NSString+Extension.h"
+#import "NSMutableString+Extension.h"
+#import "NSFileManager+Extension.h"
+#import "NSMutableArray+Extension.h"
+
+extern NSArray* MTLCopyAllDevices(void) __attribute__((weak_import));
+
+@implementation VMMComputerInformation
+
+static unsigned int _systemProfilerRequestTimeOut = 15;
+static unsigned int _appleSupportMacModelRequestTimeOut = 5;
+
++(nullable NSArray<NSDictionary*>*)systemProfilerItemsForDataType:(nonnull NSString*)dataType
+{
+    NSString* displayOutput = [NSTask runProgram:@"/usr/sbin/system_profiler" withFlags:@[@"-xml", @"-detailLevel", @"full", dataType]
+                          waitingForTimeInterval:_systemProfilerRequestTimeOut];
+    
+    NSArray* displayArray = [VMMPropertyList propertyListWithUnarchivedString:displayOutput];
+    if (displayArray == nil)
+    {
+        return nil;
+    }
+    
+    displayArray = displayArray[0][@"_items"];
+    if (displayArray == nil)
+    {
+        return nil;
+    }
+    
+    return displayArray;
+}
+    
++(NSDictionary*)systemProfilerHardwareDictionary
+{
+    NSArray* hardwareArray = [self systemProfilerItemsForDataType:SPHardwareDataType];
+    
+    if (hardwareArray == nil)
+    {
+        return @{};
+    }
+    
+    return [hardwareArray firstObject];
+}
++(nullable NSDictionary*)hardwareDictionary
+{
+    static NSDictionary* hardwareDictionary = nil;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        hardwareDictionary = [self systemProfilerHardwareDictionary];
+    });
+    
+    return hardwareDictionary;
+}
++(long long int)hardDiskSize
+{
+    NSDictionary *hdAttributes = [[NSFileManager defaultManager] attributesOfFileSystemForPath:@"/" error:nil];
+    long long int fileSystemSize = [[hdAttributes objectForKey:NSFileSystemSize] longLongValue];
+    return fileSystemSize;
+}
++(long long int)hardDiskFreeSize
+{
+    NSDictionary *hdAttributes = [[NSFileManager defaultManager] attributesOfFileSystemForPath:@"/" error:nil];
+    long long int fileSystemFreeSize = [[hdAttributes objectForKey:NSFileSystemFreeSize] longLongValue];
+    return fileSystemFreeSize;
+}
++(long long int)hardDiskUsedSize
+{
+    return self.hardDiskSize - self.hardDiskFreeSize;
+}
++(long long int)ramMemorySize
+{
+    return [[NSProcessInfo processInfo] physicalMemory];
+}
++(long long int)ramMemoryFreeSize
+{
+    return self.ramMemorySize - self.ramMemoryUsedSize;
+}
++(long long int)ramMemoryUsedSize
+{
+    // TODO: Not confirmed to be accurate yet
+    
+    long long int result;
+    
+    @autoreleasepool
+    {
+        NSString* vm_stat = [NSTask runCommand:@[@"vm_stat"]];
+        
+        int pageSize = getpagesize();
+        NSMutableString* activeSizeWithSpaces     = [[vm_stat getFragmentAfter:@"Pages active:"                 andBefore:@"."] mutableCopy];
+        NSMutableString* wiredSizeWithSpaces      = [[vm_stat getFragmentAfter:@"Pages wired down:"             andBefore:@"."] mutableCopy];
+        NSMutableString* purgeableSizeWithSpaces  = [[vm_stat getFragmentAfter:@"Pages purgeable:"              andBefore:@"."] mutableCopy];
+        NSMutableString* compressedSizeWithSpaces = [[vm_stat getFragmentAfter:@"Pages occupied by compressor:" andBefore:@"."] mutableCopy];
+        
+        if (activeSizeWithSpaces == nil)     activeSizeWithSpaces     = [[NSMutableString alloc] initWithString:@"0"];
+        if (wiredSizeWithSpaces == nil)      wiredSizeWithSpaces      = [[NSMutableString alloc] initWithString:@"0"];
+        if (purgeableSizeWithSpaces == nil)  purgeableSizeWithSpaces  = [[NSMutableString alloc] initWithString:@"0"];
+        if (compressedSizeWithSpaces == nil) compressedSizeWithSpaces = [[NSMutableString alloc] initWithString:@"0"];
+        
+        [activeSizeWithSpaces     trim];
+        [wiredSizeWithSpaces      trim];
+        [purgeableSizeWithSpaces  trim];
+        [compressedSizeWithSpaces trim];
+        
+        result = ([activeSizeWithSpaces longLongValue]    + [wiredSizeWithSpaces longLongValue] +
+                [purgeableSizeWithSpaces longLongValue] + [compressedSizeWithSpaces longLongValue])*pageSize;
+    }
+    
+    return result;
+}
++(nullable NSString*)processorNameAndSpeed
+{
+    static NSString *processorNameAndSpeed = nil;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        NSString* processorName  = self.hardwareDictionary[@"cpu_type"];
+        NSString* processorSpeed = self.hardwareDictionary[@"current_processor_speed"];
+        
+        if (processorName != nil && processorName.length > 0)
+        {
+            processorNameAndSpeed = [NSString stringWithFormat:@"%@ %@",processorName,processorSpeed];
+        }
+        else
+        {
+            processorName = [NSTask runCommand:@[@"sysctl", @"-n", @"machdep.cpu.brand_string"]];
+            
+            if (processorName != nil && processorName.length > 0)
+            {
+                while ([processorName contains:@"  "])
+                {
+                    processorName = [processorName stringByReplacingOccurrencesOfString:@"  " withString:@" "];
+                }
+                
+                processorNameAndSpeed = processorName;
+            }
+            else
+            {
+                processorNameAndSpeed = processorSpeed;
+            }
+        }
+    });
+    
+    return processorNameAndSpeed;
+}
++(double)processorUsage
+{
+    // TODO: Not confirmed to be accurate yet
+    
+    double cpuUsageSum = 0.0;
+    
+    @autoreleasepool
+    {
+        NSString* ps = [NSTask runCommand:@[@"ps", @"-A", @"-o" ,@"%cpu"]];
+        ps = [ps stringByReplacingOccurrencesOfString:@"," withString:@"."];
+        
+        for (NSString* process in [ps componentsSeparatedByString:@"\n"])
+        {
+            cpuUsageSum += [[[process mutableCopy] trim] doubleValue];
+        }
+        
+        NSString* numberOfCpus = [NSTask runCommand:@[@"sysctl", @"hw.physicalcpu"]];
+        numberOfCpus = [numberOfCpus getFragmentAfter:@" " andBefore:nil];
+        if (!numberOfCpus || numberOfCpus.intValue == 0) return -1;
+        
+        cpuUsageSum = cpuUsageSum/numberOfCpus.intValue;
+    }
+    
+    return cpuUsageSum / 100;
+}
++(nullable NSString*)macModel
+{
+    static NSString *macModel = nil;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        @autoreleasepool
+        {
+            NSString* otherOption;
+            
+            NSString* sysProfFile = [NSString stringWithFormat:@"%@/Library/Preferences/com.apple.SystemProfiler.plist",NSHomeDirectory()];
+            
+            if ([[NSFileManager defaultManager] regularFileExistsAtPath:sysProfFile])
+            {
+                NSDictionary* sysProf = [NSDictionary dictionaryWithContentsOfFile:sysProfFile];
+                
+                if (sysProf != nil)
+                {
+                    NSDictionary* cpuNames = sysProf[@"CPU Names"];
+                    
+                    if (cpuNames != nil && [cpuNames isKindOfClass:[NSDictionary class]] && cpuNames.allKeys.count >= 1)
+                    {
+                        otherOption = cpuNames[cpuNames.allKeys.lastObject];
+                        
+                        for (NSString* cpuName in cpuNames.allValues)
+                        {
+                            if ([cpuName contains:@"inch"])
+                            {
+                                macModel = cpuName;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            
+            if (macModel == nil)
+            {
+                NSString* macSerial = self.hardwareDictionary[@"serial_number"];
+                
+                if (macSerial != nil && macSerial.length >= 8)
+                {
+                    // Depending on if your serial numer is 11 or 12 characters long; take the last 3 or 4 characters
+                    macSerial = [macSerial substringFromIndex:8];
+                    
+                    NSString* macInfoURL = [NSString stringWithFormat:@"http://support-sp.apple.com/sp/product?cc=%@",macSerial];
+                    
+                    __block NSString* macInfo = nil;
+                    [NSString stringWithContentsOfURL:[NSURL URLWithString:macInfoURL] encoding:NSUTF8StringEncoding
+                                      timeoutInterval:_appleSupportMacModelRequestTimeOut withCompletionHandler:
+                     ^(NSUInteger statusCode, NSString *string, NSError *error)
+                    {
+                        if (!error && statusCode >= 200 && statusCode < 300)
+                        {
+                            macInfo = string;
+                        }
+                    }];
+                    
+                    if (macInfo != nil && macInfo.length > 0)
+                    {
+                        macModel = [macInfo getFragmentAfter:@"<configCode>" andBefore:@"</configCode>"];
+                        
+                        if (macModel.length == 0)
+                        {
+                            macModel = nil;
+                        }
+                    }
+                }
+            }
+                
+            if (macModel == nil)
+            {
+                if (otherOption != nil)
+                {
+                    macModel = otherOption;
+                }
+                else
+                {
+                    macModel = self.hardwareDictionary[@"machine_model"];
+                }
+            }
+        }
+    });
+    
+    return macModel;
+}
+
++(nullable NSString*)macOsVersion
+{
+    NSString* completeMacOsVersion = [self completeMacOsVersion];
+    if (completeMacOsVersion == nil) return nil;
+    
+    NSArray* components = [completeMacOsVersion componentsSeparatedByString:@"."];
+    if (components.count < 2) return nil;
+    
+    return [NSString stringWithFormat:@"%@.%@",components[0],components[1]];
+}
++(nullable NSString*)completeMacOsVersion
+{
+    static NSString *macOsVersion = nil;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        @autoreleasepool
+        {
+            if ([[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)])
+            {
+                NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
+                if (version.majorVersion >= 10)
+                {
+                    macOsVersion = [NSString stringWithFormat:@"%ld.%ld.%ld",
+                                    version.majorVersion, version.minorVersion, version.patchVersion];
+                }
+            }
+            
+            // Gestalt shouldn't be used, even in older systems. It may bring the wrong value.
+            // Reference: https://discussions.apple.com/thread/6686435
+            
+            if (macOsVersion == nil)
+            {
+                macOsVersion = [NSTask runCommand:@[@"sw_vers", @"-productVersion"]];
+            }
+            
+            if (macOsVersion == nil)
+            {
+                NSString* plistFile = @"/System/Library/CoreServices/SystemVersion.plist";
+                NSDictionary *systemVersionDictionary = [NSDictionary dictionaryWithContentsOfFile:plistFile];
+                macOsVersion = systemVersionDictionary[@"ProductVersion"];
+            }
+            
+            if (macOsVersion == nil)
+            {
+                macOsVersion = @"";
+            }
+        }
+    });
+    
+    return macOsVersion;
+}
++(BOOL)isSystemMacOsEqualOrSuperiorTo:(nonnull NSString*)version
+{
+    static NSMutableDictionary *macOsCompatibility = nil;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        macOsCompatibility = [[NSMutableDictionary alloc] init];
+    });
+    
+    if (macOsCompatibility[version] != nil)
+    {
+        return [macOsCompatibility[version] boolValue];
+    }
+    
+    BOOL compatible = [VMMVersion compareVersionString:version withVersionString:self.macOsVersion] != VMMVersionCompareFirstIsNewest;
+    macOsCompatibility[version] = @(compatible);
+    return compatible;
+}
+
++(nullable NSString*)macOsBuildVersion
+{
+    static NSString *macOsBuildVersion = nil;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        @autoreleasepool
+        {
+            macOsBuildVersion = [NSTask runCommand:@[@"sw_vers", @"-buildVersion"]];
+            
+            if (macOsBuildVersion == nil)
+            {
+                NSString* plistFile = @"/System/Library/CoreServices/SystemVersion.plist";
+                NSDictionary *systemVersionDictionary = [NSDictionary dictionaryWithContentsOfFile:plistFile];
+                macOsBuildVersion = systemVersionDictionary[@"ProductBuildVersion"];
+            }
+            
+            if (macOsBuildVersion == nil)
+            {
+                macOsBuildVersion = @"";
+            }
+        }
+    });
+    
+    return macOsBuildVersion;
+}
+
++(BOOL)isUserMemberOfUserGroup:(VMMUserGroup)userGroup
+{
+    static NSArray *userGroups = nil;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        // Obtaining a string with the usergroups of the current user
+        NSString* usergroupsString = [NSTask runCommand:@[@"id", @"-G"]];
+        userGroups = [usergroupsString componentsSeparatedByString:@" "];
+    });
+    
+    return [userGroups containsObject:[NSString stringWithFormat:@"%d",userGroup]];
+}
+
++(BOOL)isSipEnabled
+{
+    return [[NSTask runCommand:@[@"csrutil", @"status"]] contains:@" enabled"];
+}
++(BOOL)are32bitProcessesEnabled
+{
+    return [[NSTask runCommand:@[@"nvram", @"boot-args"]] contains:@"no32exec=0"];
+}
+
++(nonnull NSArray*)metalDevices
+{
+    // References:
+    // https://developer.apple.com/documentation/metal/fundamental_components/macos_devices/getting_different_types_of_gpus?language=objc
+    // https://developer.apple.com/documentation/metal/1433367-mtlcopyalldevices?language=objc
+    
+    if (MTLCopyAllDevices != NULL) {
+        return MTLCopyAllDevices();
+    }
+    
+    return @[];
+}
+
++(BOOL)isSystemIntegrityProtectionEnabled
+{
+    NSString* output = [NSTask runProgram:@"csrutil" withFlags:@[@"status"]];
+    return [output contains:@" enabled."];
+}
+
++(nonnull NSArray<NSDictionary*>*)thunderboltPorts
+{
+    NSMutableArray* thunderboltOutput = [[NSMutableArray alloc] init];
+    
+    CFMutableDictionaryRef matchDict = IOServiceMatching("AppleThunderboltHAL");
+    
+    io_iterator_t iterator;
+    if (IOServiceGetMatchingServices(kIOMasterPortDefault,matchDict,&iterator) == kIOReturnSuccess)
+    {
+        io_registry_entry_t regEntry;
+        while ((regEntry = IOIteratorNext(iterator)))
+        {
+            CFMutableDictionaryRef serviceDictionary;
+            if (IORegistryEntryCreateCFProperties(regEntry, &serviceDictionary, kCFAllocatorDefault, kNilOptions) != kIOReturnSuccess)
+            {
+                IOObjectRelease(regEntry);
+                continue;
+            }
+            
+            NSMutableDictionary* service = (__bridge NSMutableDictionary*)serviceDictionary;
+            [thunderboltOutput addObject:service];
+            CFRelease(serviceDictionary);
+            
+            IOObjectRelease(regEntry);
+        }
+        
+        IOObjectRelease(iterator);
+    }
+    
+    return thunderboltOutput;
+}
+
++(VMMExternalGPUCompatibilityWithMacOS)macOsCompatibilityWithExternalGPU
+{
+    if ([self isSystemMacOsEqualOrSuperiorTo:@"10.13.4"]) {
+        // Full support
+        // https://support.apple.com/en-us/HT208544
+        return VMMExternalGPUCompatibilityWithMacOS_Supported;
+    }
+    if ([self isSystemMacOsEqualOrSuperiorTo:@"10.13"]) {
+        // Partial support / needs a different kind of hack
+        // https://github.com/learex/macOS-eGPU
+        // https://egpu.io/macos-high-sierra-official-external-gpu/
+        return VMMExternalGPUCompatibilityWithMacOS_MinorHack;
+    }
+    if ([self isSystemMacOsEqualOrSuperiorTo:@"10.9"]) {
+        // No support, but works with hacks
+        // http://forum.notebookreview.com/threads/diy-egpu-macos-experiences.660311/page-11
+        // https://odd-one-out.serek.eu/projects/egpu-osx-maverick-nvidia-gtx-760-using-pe4l/
+        // https://egpu.io/forums/mac-setup/automate-egpu-sh-is-reborn-with-amd-polaris-fiji-support-for-macos/
+        // https://www.techinferno.com/index.php?/forums/topic/7657-guide-enabling-egpu-display-output-in-yosemite/
+        // http://forum.netkas.org/index.php?topic=11140.0
+        // https://egpu.io/setup-guide-external-graphics-card-mac/
+        return VMMExternalGPUCompatibilityWithMacOS_MajorHack;
+    }
+    
+    // No support and no hacks
+    return VMMExternalGPUCompatibilityWithMacOS_None;
+}
+
+@end
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMDeviceObserver.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMDeviceObserver.h
@@ -1,0 +1,47 @@
+//
+//  VMMDeviceObserver.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 09/08/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import <IOKit/hid/IOHIDManager.h>
+#import <IOKit/hid/IOHIDKeys.h>
+#include <IOKit/usb/IOUSBLib.h>
+
+#define VMMDeviceObserverTypesKeyboard  @[@(kHIDUsage_GD_Keyboard), @(kHIDUsage_GD_Keypad)]
+#define VMMDeviceObserverTypesJoystick  @[@(kHIDUsage_GD_Joystick), @(kHIDUsage_GD_GamePad), @(kHIDUsage_GD_MultiAxisController)]
+
+static int const IOHIDMaxIntegerValueBytes = 4;
+
+BOOL IOHIDDeviceGetLongProperty(IOHIDDeviceRef _Nullable inIOHIDDeviceRef, CFStringRef _Nonnull inKey, long * _Nonnull outValue);
+long IOHIDDeviceGetUsage(IOHIDDeviceRef _Nullable device);
+long IOHIDDeviceGetVendorID(IOHIDDeviceRef _Nullable device);
+
+@protocol VMMDeviceObserverDelegate
+
+@property (nonatomic, nullable) IOHIDManagerRef hidManager;
+
+@optional
+
+-(void)observedConnectionOfDevice:(nonnull IOHIDDeviceRef)device;
+-(void)observedRemovalOfDevice:(nonnull IOHIDDeviceRef)device;
+-(void)observedEventWithName:(nullable CFStringRef)name cookie:(IOHIDElementCookie)cookie usage:(uint32_t)usage value:(CFIndex)value device:(nonnull IOHIDDeviceRef)device;
+-(void)observedReportWithID:(uint32_t)reportID data:(nonnull uint8_t*)report type:(IOHIDReportType)reportType length:(CFIndex)reportLength device:(nonnull IOHIDDeviceRef)device;
+-(CFIndex)receivedPacketMaxSize;
+
+@end
+
+
+@interface VMMDeviceObserver : NSObject
+
++(nonnull instancetype)sharedObserver;
+-(BOOL)observeDevicesOfTypes:(nonnull NSArray<NSNumber*>*)types forDelegate:(nonnull id<VMMDeviceObserverDelegate>)actionDelegate;
+-(BOOL)stopObservingForDelegate:(nonnull id<VMMDeviceObserverDelegate>)actionDelegate;
+
+@property (nonatomic) uint8_t* _Nullable receivedReport;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMDeviceObserver.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMDeviceObserver.m
@@ -1,0 +1,171 @@
+//
+//  VMMDeviceObserver.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 09/08/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "VMMDeviceObserver.h"
+
+#import "NSArray+Extension.h"
+#import "NSMutableArray+Extension.h"
+
+#import "VMMLogUtility.h"
+
+BOOL IOHIDDeviceGetLongProperty(IOHIDDeviceRef _Nullable inIOHIDDeviceRef, CFStringRef _Nonnull inKey, long * _Nonnull outValue)
+{
+    BOOL result = FALSE;
+    if (inIOHIDDeviceRef)
+    {
+        assert(IOHIDDeviceGetTypeID() == CFGetTypeID(inIOHIDDeviceRef));
+        
+        CFTypeRef tCFTypeRef = IOHIDDeviceGetProperty(inIOHIDDeviceRef, inKey);
+        if (tCFTypeRef)
+        {
+            if (CFNumberGetTypeID() == CFGetTypeID(tCFTypeRef))
+            {
+                result = CFNumberGetValue((CFNumberRef)tCFTypeRef, kCFNumberSInt32Type, outValue);
+            }
+        }
+    }
+    
+    return result;
+}
+long IOHIDDeviceGetUsage(IOHIDDeviceRef _Nullable device)
+{
+    long result = 0;
+    IOHIDDeviceGetLongProperty(device, CFSTR(kIOHIDPrimaryUsageKey), &result);
+    return result;
+}
+long IOHIDDeviceGetVendorID(IOHIDDeviceRef _Nullable device)
+{
+    long vendorID = 0;
+    IOHIDDeviceGetLongProperty(device, CFSTR(kIOHIDVendorIDKey), &vendorID);
+    return vendorID;
+}
+
+@implementation VMMDeviceObserver
+
++(nonnull instancetype)sharedObserver
+{
+    static VMMDeviceObserver* sharedObserver = nil;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        sharedObserver = [[VMMDeviceObserver alloc] init];
+    });
+    
+    return sharedObserver;
+}
+
+-(BOOL)observeDevicesOfTypes:(nonnull NSArray<NSNumber*>*)types forDelegate:(nonnull id<VMMDeviceObserverDelegate>)actionDelegate
+{
+    if (actionDelegate.hidManager != NULL) {
+        [self stopObservingForDelegate:actionDelegate];
+    }
+    
+    actionDelegate.hidManager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
+    
+    NSMutableArray* deviceTypes = [types map:^id(id object) {
+        return @{@(kIOHIDDeviceUsagePageKey): @(kHIDPage_GenericDesktop), @(kIOHIDDeviceUsageKey): object};
+    }];
+    
+    IOHIDManagerSetDeviceMatchingMultiple(actionDelegate.hidManager, (__bridge CFArrayRef)deviceTypes);
+    
+    IOHIDManagerRegisterDeviceMatchingCallback(actionDelegate.hidManager, &Handle_DeviceMatchingCallback, (__bridge void*)actionDelegate);
+    IOHIDManagerRegisterDeviceRemovalCallback (actionDelegate.hidManager, &Handle_DeviceRemovalCallback,  (__bridge void*)actionDelegate);
+    
+    IOHIDManagerScheduleWithRunLoop(actionDelegate.hidManager, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+    
+    IOReturn IOReturn = IOHIDManagerOpen(actionDelegate.hidManager, kIOHIDOptionsTypeNone);
+    
+    IOHIDManagerRegisterInputValueCallback(actionDelegate.hidManager, Handle_DeviceEventCallback, (__bridge void*)actionDelegate);
+    
+    return (IOReturn == kIOReturnSuccess);
+}
+-(BOOL)stopObservingForDelegate:(nonnull id<VMMDeviceObserverDelegate>)actionDelegate
+{
+    if (actionDelegate.hidManager == NULL) return true;
+    
+    IOReturn IOReturn = IOHIDManagerClose(actionDelegate.hidManager, kIOHIDOptionsTypeNone);
+    actionDelegate.hidManager = NULL;
+    
+    return (IOReturn == kIOReturnSuccess);
+}
+
+static void Handle_DeviceMatchingCallback(void *inContext, IOReturn inResult, void *inSender, IOHIDDeviceRef inIOHIDDeviceRef)
+{
+    if (inIOHIDDeviceRef == NULL) return;
+    
+    VMMDeviceObserver* sender = VMMDeviceObserver.sharedObserver;
+    
+    NSObject<VMMDeviceObserverDelegate>* actionDelegate = (__bridge NSObject<VMMDeviceObserverDelegate>*)inContext;
+    if (![actionDelegate respondsToSelector:@selector(observedConnectionOfDevice:)]) return;
+    
+    if ([actionDelegate respondsToSelector:@selector(receivedPacketMaxSize)])
+    {
+        sender.receivedReport = (uint8_t *)calloc(actionDelegate.receivedPacketMaxSize, sizeof(uint8_t));
+
+        IOHIDDeviceScheduleWithRunLoop(inIOHIDDeviceRef, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+        IOHIDDeviceRegisterInputReportCallback(inIOHIDDeviceRef, sender.receivedReport, actionDelegate.receivedPacketMaxSize,
+                                               Handle_DeviceReportCallback, inContext);
+    }
+    
+    [actionDelegate observedConnectionOfDevice:inIOHIDDeviceRef];
+}
+static void Handle_DeviceRemovalCallback (void *inContext, IOReturn inResult, void *inSender, IOHIDDeviceRef inIOHIDDeviceRef)
+{
+    if (inIOHIDDeviceRef == NULL) return;
+    
+    NSObject<VMMDeviceObserverDelegate>* actionDelegate = (__bridge NSObject<VMMDeviceObserverDelegate>*)inContext;
+    if (![actionDelegate respondsToSelector:@selector(observedRemovalOfDevice:)]) return;
+    
+    [actionDelegate observedRemovalOfDevice:inIOHIDDeviceRef];
+}
+static void Handle_DeviceEventCallback   (void *inContext, IOReturn inResult, void *inSender, IOHIDValueRef value)
+{
+    IOHIDElementRef element = IOHIDValueGetElement(value);      // Pressed key
+    if (element == NULL) return;
+    
+    IOHIDDeviceRef device = IOHIDElementGetDevice(element);     // Device
+    if (device == NULL) return;
+    
+    CFIndex elementValue = -1;
+    if (IOHIDValueGetLength(value) <= IOHIDMaxIntegerValueBytes)
+    {
+        //
+        // If the size of the package is bigger than 4 bytes, IOHIDValueGetIntegerValue() will cause
+        // a SEGFAULT exception. That should solve the crash caused by that exception, since that
+        // kind of exception can't be caught by a try/catch.
+        //
+        // https://github.com/nagyistoce/macifom/issues/3
+        // https://groups.google.com/forum/#!topic/pyglet-users/O3RuDqmYr5Y
+        //
+        
+        elementValue = IOHIDValueGetIntegerValue(value);    // Actual state of the pressed key
+    }
+    
+    IOHIDElementCookie cookie = IOHIDElementGetCookie(element); // Cookie of the pressed key
+    uint32_t usage = IOHIDElementGetUsage(element);             // Usage of the pressed key
+    CFStringRef name = IOHIDElementGetName(element);
+    
+    NSObject<VMMDeviceObserverDelegate>* actionDelegate = (__bridge NSObject<VMMDeviceObserverDelegate>*)inContext;
+    if (actionDelegate == nil) return;
+    if (![actionDelegate respondsToSelector:@selector(observedEventWithName:cookie:usage:value:device:)]) return;
+    
+    [actionDelegate observedEventWithName:name cookie:cookie usage:usage value:elementValue device:device];
+}
+
+static void Handle_DeviceReportCallback   (void* context, IOReturn result, void* sender, IOHIDReportType type, uint32_t reportID, uint8_t*               report, CFIndex reportLength)
+{
+    IOHIDDeviceRef device = (IOHIDDeviceRef)sender;
+    
+    NSObject<VMMDeviceObserverDelegate>* actionDelegate = (__bridge NSObject<VMMDeviceObserverDelegate>*)context;
+    if (actionDelegate == nil) return;
+    if (![actionDelegate respondsToSelector:@selector(observedReportWithID:data:type:length:device:)]) return;
+    
+    [actionDelegate observedReportWithID:reportID data:report type:type length:reportLength device:device];
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMDeviceSimulator.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMDeviceSimulator.h
@@ -1,0 +1,17 @@
+//
+//  VMMDeviceSimulator.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 01/10/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface VMMDeviceSimulator : NSObject
+
++(void)simulateCursorClickAtScreenPoint:(CGPoint)clickPoint;
+
++(void)simulateVirtualKeycode:(CGKeyCode)keyCode withKeyDown:(BOOL)keyPressed;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMDeviceSimulator.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMDeviceSimulator.m
@@ -1,0 +1,48 @@
+//
+//  VMMDeviceSimulator.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 01/10/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+//  Reference:
+//  https://stackoverflow.com/questions/28485257/objective-c-mac-os-x-simulate-a-mouse-click-event-onto-a-specific-applicatio
+//
+
+#import "VMMDeviceSimulator.h"
+
+@implementation VMMDeviceSimulator
+
++(void)simulateCursorClickAtScreenPoint:(CGPoint)clickPoint
+{
+    // TODO: In macOS Mojave, the method below requires accessibility permissions.
+    // https://objective-see.com/blog/blog_0x36.html
+    // https://forums.developer.apple.com/thread/105667
+    //
+    // Still couldn't find a suitable workaround for requiring the permission
+    // a second time in case the user denied by mistake.
+
+    CGEventRef theEvent = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseDown, clickPoint, kCGMouseButtonLeft);
+    CGEventPost(kCGHIDEventTap, theEvent);
+    CGEventSetType(theEvent, kCGEventLeftMouseUp);
+    CGEventPost(kCGHIDEventTap, theEvent);
+    
+    CGEventSetIntegerValueField(theEvent, kCGMouseEventClickState, 2);
+    
+    CGEventSetType(theEvent, kCGEventLeftMouseDown);
+    CGEventPost(kCGHIDEventTap, theEvent);
+    
+    CGEventSetType(theEvent, kCGEventLeftMouseUp);
+    CGEventPost(kCGHIDEventTap, theEvent);
+    
+    CFRelease(theEvent);
+}
+
++(void)simulateVirtualKeycode:(CGKeyCode)keyCode withKeyDown:(BOOL)keyPressed
+{
+    CGEventRef cmdd = CGEventCreateKeyboardEvent(NULL, keyCode, keyPressed);
+    CGEventPost(kCGHIDEventTap, cmdd);
+    CFRelease(cmdd);
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMDockProgressIndicator.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMDockProgressIndicator.h
@@ -1,0 +1,40 @@
+//
+//  VMMDockProgressIndicator.h
+//  ObjectiveC_Extension
+//
+//  Copyright (c) 2014, hokein
+//  All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright
+//  notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//  notice, this list of conditions and the following disclaimer in the
+//  documentation and/or other materials provided with the distribution.
+//  * Neither the name of the <organization> nor the
+//  names of its contributors may be used to endorse or promote products
+//  derived from this software without specific prior written permission.
+
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+//  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//  Reference:
+//  https://github.com/hokein/DockProgressBar
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface VMMDockProgressIndicator : NSProgressIndicator
+
++ (nonnull VMMDockProgressIndicator*)sharedInstance;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMDockProgressIndicator.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMDockProgressIndicator.m
@@ -1,0 +1,124 @@
+//
+//  VMMDockProgressIndicator.m
+//  ObjectiveC_Extension
+//
+//  Copyright (c) 2014, hokein
+//  All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright
+//  notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//  notice, this list of conditions and the following disclaimer in the
+//  documentation and/or other materials provided with the distribution.
+//  * Neither the name of the <organization> nor the
+//  names of its contributors may be used to endorse or promote products
+//  derived from this software without specific prior written permission.
+
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+//  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//  Reference:
+//  https://github.com/hokein/DockProgressBar
+//
+
+#import "VMMDockProgressIndicator.h"
+
+#import "NSBundle+Extension.h"
+#import "NSColor+Extension.h"
+
+@implementation VMMDockProgressIndicator
+
+static VMMDockProgressIndicator* progress_bar;
+
++ (nonnull VMMDockProgressIndicator*)sharedInstance
+{
+    NSDockTile* dock_tile = [NSApp dockTile];
+    
+    if (!progress_bar)
+    {
+        progress_bar = [[VMMDockProgressIndicator alloc] initWithFrame:NSMakeRect(0.0f, 0.0f, dock_tile.size.width, 15.0f)];
+        [progress_bar setStyle:NSProgressIndicatorBarStyle];
+        [progress_bar setIndeterminate:NO];
+        [progress_bar setBezeled:YES];
+        [progress_bar setMinValue:0];
+        [progress_bar setMaxValue:1];
+    }
+    
+    if (dock_tile.contentView == nil)
+    {
+        NSImage* contentViewImage;
+        
+        @try
+        {
+            contentViewImage = [NSApp applicationIconImage];
+        }
+        @catch(NSException* exception)
+        {
+            NSBundle* mainBundle = [NSBundle originalMainBundle];
+            
+            @try
+            {
+                contentViewImage = [mainBundle bundleIcon];
+            }
+            @catch(NSException* otherException)
+            {
+                [exception raise];
+            }
+        }
+        
+        NSImageView* contentView = [[NSImageView alloc] init];
+        [contentView setImage:contentViewImage];
+        [dock_tile setContentView:contentView];
+        [contentView addSubview:progress_bar];
+    }
+    
+    return progress_bar;
+}
+
+- (void)drawRect:(NSRect)dirtyRect
+{
+    NSRect rect = NSInsetRect(self.bounds, 1.0, 1.0);
+    CGFloat radius = rect.size.height / 2;
+    NSBezierPath* bezier_path = [NSBezierPath bezierPathWithRoundedRect:rect xRadius:radius yRadius:radius];
+    [bezier_path setLineWidth:2.0];
+    [[NSColor grayColor] set];
+    [bezier_path stroke];
+    
+    // Fill the rounded rect.
+    rect = NSInsetRect(rect, 2.0, 2.0);
+    radius = rect.size.height / 2;
+    bezier_path = [NSBezierPath bezierPathWithRoundedRect:rect xRadius:radius yRadius:radius];
+    [bezier_path setLineWidth:1.0];
+    [bezier_path addClip];
+    
+    // Calculate the progress width.
+    rect.size.width = floor(rect.size.width * ((self.doubleValue - self.minValue) / (self.maxValue - self.minValue)));
+    
+    // Fill the progress bar with color blue.
+    [RGB(51, 153, 255) set];
+    NSRectFill(rect);
+}
+
+- (void)setHidden:(BOOL)hidden
+{
+    [super setHidden:hidden];
+    [[NSApp dockTile] display];
+}
+
+- (void)setDoubleValue:(double)doubleValue
+{
+    [super setDoubleValue:doubleValue];
+    [[NSApp dockTile] display];
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMKeyCaptureField.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMKeyCaptureField.h
@@ -1,0 +1,25 @@
+//
+//  VMMKeyCaptureField.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 18/08/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+#import "VMMDeviceObserver.h"
+#import "VMMUsageKeycode.h"
+
+@protocol VMMKeyCaptureFieldDelegate <NSObject>
+-(void)keyCaptureField:(nonnull NSTextField*)field didChangedKeyUsageKeycode:(uint32_t)keyUsage;
+@end
+
+@interface VMMKeyCaptureField : NSTextField<VMMDeviceObserverDelegate>
+
+@property (nonatomic, strong, nullable) IBOutlet NSObject<VMMKeyCaptureFieldDelegate>* keyCaptureDelegate;
+@property (nonatomic, nullable) IOHIDManagerRef hidManager;
+@property (nonatomic) uint32_t keyUsageKeycode;
+
+@end
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMKeyCaptureField.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMKeyCaptureField.m
@@ -1,0 +1,119 @@
+//
+//  VMMKeyCaptureField.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 18/08/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "VMMKeyCaptureField.h"
+
+#import "VMMUsageKeycode.h"
+#import "VMMLocalizationUtility.h"
+
+static VMMKeyCaptureField* _activeKeyCaptureField;
+
+@implementation VMMKeyCaptureField
+
+-(void)awakeFromNib
+{
+    _keyUsageKeycode = -1;
+    _activeKeyCaptureField = nil;
+}
+
+-(void)startEditing
+{
+    if (_activeKeyCaptureField)
+    {
+        if (_activeKeyCaptureField == self) return;
+        
+        [VMMDeviceObserver.sharedObserver stopObservingForDelegate:_activeKeyCaptureField];
+    }
+    
+    _activeKeyCaptureField = self;
+    [VMMDeviceObserver.sharedObserver observeDevicesOfTypes:VMMDeviceObserverTypesKeyboard forDelegate:self];
+}
+-(void)stopEditing
+{
+    if (_activeKeyCaptureField == self)
+    {
+        _activeKeyCaptureField = nil;
+    }
+    
+    [VMMDeviceObserver.sharedObserver stopObservingForDelegate:self];
+}
+
+-(BOOL)textShouldBeginEditing:(NSText *)textObject
+{
+    return false;
+}
+-(void)textDidEndEditing:(NSNotification *)notification
+{
+    [self stopEditing];
+}
+
+-(BOOL)becomeFirstResponder
+{
+    BOOL result = [super becomeFirstResponder];
+    if (result) [self startEditing];
+    return result;
+}
+-(BOOL)resignFirstResponder
+{
+    BOOL result = [super resignFirstResponder];
+    if (result) [self stopEditing];
+    return result;
+}
+
+-(void)observedEventWithName:(CFStringRef)name cookie:(IOHIDElementCookie)cookie usage:(uint32_t)usage
+                       value:(CFIndex)value device:(IOHIDDeviceRef)device
+{
+    if (!self.window.isKeyWindow) return;
+    if (![[self.window firstResponder] isKindOfClass:NSText.class]) return;
+    
+    if (_activeKeyCaptureField != self) return;
+    if (value != 1) return;
+    
+    // Exception
+    if (usage == 128 && cookie == 242) return; // Logitech G600 Mouse Left-button click
+    if (usage == 128 && cookie == 243) return; // Logitech G600 Mouse Middle-button click
+    if (usage == 128 && cookie == 244) return; // Logitech G600 Mouse Right-button click
+    
+    dispatch_async(dispatch_get_main_queue(), ^
+    {
+        [self setKeyUsageKeycode:usage];
+        
+        if (self->_keyCaptureDelegate)
+        {
+            [self->_keyCaptureDelegate keyCaptureField:self didChangedKeyUsageKeycode:usage];
+        }
+    });
+}
+
+-(void)setKeyUsageKeycode:(uint32_t)keyUsageKeycode
+{
+    if (keyUsageKeycode == -1)
+    {
+        _keyUsageKeycode = -1;
+        [self setStringValue:@""];
+        return;
+    }
+    
+    _keyUsageKeycode = keyUsageKeycode;
+    NSString* keyName = [VMMUsageKeycode nameOfUsageKeycode:keyUsageKeycode];
+    [self setStringValue:keyName ? keyName : [NSString stringWithFormat:VMMLocalizedString(@"Unknown Key (%d)"),keyUsageKeycode]];
+}
+
+-(IBAction)clearField:(id)sender
+{
+    _keyUsageKeycode = -1;
+    [self setStringValue:@""];
+    
+    if (_keyCaptureDelegate)
+    {
+        [_keyCaptureDelegate keyCaptureField:self didChangedKeyUsageKeycode:_keyUsageKeycode];
+    }
+}
+
+@end
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMLocalizationUtility.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMLocalizationUtility.h
@@ -1,0 +1,12 @@
+//
+//  VMMLocalizationUtility.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 06/12/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#define VMMLocalizationNotNeeded(S) [NSMutableString stringWithString:S]
+#define VMMLocalizedString(S)       NSLocalizedString(S, nil)
+
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMLogUtility.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMLogUtility.h
@@ -1,0 +1,31 @@
+//
+//  VMMLogUtility.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 31/07/2017.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "ObjCExtensionConfig.h"
+#import "NSString+Extension.h"
+
+#ifdef DEBUG
+    #if NSDEBUGLOG_SHOULD_PRINT_TO_A_DESKTOP_FILE_TOO == true
+        #define NSDebugLog(FORMAT, ...) system([[NSString stringWithFormat:@"echo \"%@\" | tee -a ~/Desktop/debug.log", [[[[NSString stringWithFormat:FORMAT, ##__VA_ARGS__] stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""] stringByReplacingOccurrencesOfString:@"\n" withString:@"\\n"] stringByRemovingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"\0"]]] UTF8String])
+    #else
+        #define NSDebugLog(FORMAT, ...) system([[NSString stringWithFormat:@"echo \"%@\"", [[[[NSString stringWithFormat:FORMAT, ##__VA_ARGS__] stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""] stringByReplacingOccurrencesOfString:@"\n" withString:@"\\n"] stringByRemovingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"\0"]]] UTF8String])
+    #endif
+#else
+    #define NSDebugLog(...)
+#endif
+
+void NSStackTraceLog(void);
+
+// Source:
+// https://gist.github.com/sfider/3072143
+
+#define measureTime(__message) \
+    for (CFAbsoluteTime startTime##__LINE__ = CFAbsoluteTimeGetCurrent(), endTime##__LINE__ = 0.0; endTime##__LINE__ == 0.0; \
+    NSDebugLog(@"'%@' took %.6fs", (__message), (endTime##__LINE__ = CFAbsoluteTimeGetCurrent()) - startTime##__LINE__))
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMLogUtility.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMLogUtility.m
@@ -1,0 +1,14 @@
+//
+//  VMMLogUtility.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 19/12/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import "VMMLogUtility.h"
+
+void NSStackTraceLog(void)
+{
+    NSDebugLog(@"%@",[NSThread callStackSymbols]);
+}

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMMenu.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMMenu.h
@@ -1,0 +1,21 @@
+//
+//  VMMMenu.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 03/02/19.
+//  Copyright © 2019 VitorMM. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface VMMMenu : NSMenu
+
++ (void)forceLightMenu;
++ (void)forceDarkMenu;
++ (void)forceSystemMenu;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMMenu.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMMenu.m
@@ -1,0 +1,123 @@
+//
+//  VMMMenu.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 03/02/19.
+//  Copyright © 2019 VitorMM. All rights reserved.
+//
+
+#import "VMMMenu.h"
+
+#import <Carbon/Carbon.h>
+#import <objc/runtime.h>
+
+#if __LP64__
+extern void SetMenuItemProperty(MenuRef         menu,
+                                MenuItemIndex   item,
+                                OSType          propertyCreator,
+                                OSType          propertyTag,
+                                ByteCount       propertySize,
+                                const void *    propertyData);
+#endif
+
+
+@interface NSMenu (Private)
+- (id)_menuImpl;
+@end
+
+
+@protocol NSCarbonMenuImplProtocol <NSObject>
+- (MenuRef)_principalMenuRef;
+@end
+
+
+@interface NSMenu (DarkPrivate)
+- (void)makeDark;
+@end
+
+
+@interface NSMenuDarkMaker : NSObject
+{
+    NSMenu * mMenu;
+}
+- (id)initWithMenu:(NSMenu *)menu;
+@end
+
+@implementation VMMMenu
+
+static int MAKE_DARK_KEY;
+
+static BOOL FORCE_LIGHT;
+static BOOL FORCE_DARK;
+
++ (void)forceLightMenu {
+    FORCE_LIGHT = true;
+    FORCE_DARK = false;
+}
++ (void)forceDarkMenu {
+    FORCE_LIGHT = false;
+    FORCE_DARK = true;
+}
++ (void)forceSystemMenu {
+    FORCE_LIGHT = false;
+    FORCE_DARK = false;
+}
+
+-(instancetype)init
+{
+    self = [super init];
+    if (self) {
+        NSMenuDarkMaker * maker = [[NSMenuDarkMaker alloc] initWithMenu:self];
+        objc_setAssociatedObject(self, &MAKE_DARK_KEY, maker, OBJC_ASSOCIATION_RETAIN);
+    }
+    return self;
+}
+
+- (void)makeDark
+{
+    if (FORCE_LIGHT || FORCE_DARK)
+    {
+        id impl = [self _menuImpl];
+        if ([impl respondsToSelector:@selector(_principalMenuRef)]) {
+            MenuRef m = [impl _principalMenuRef];
+            if (m) {
+                char on = FORCE_DARK ? 1 : 0;
+                SetMenuItemProperty(m, 0, 'dock', 'dark', 1, &on);
+            }
+        }
+        
+        for (NSMenuItem * item in self.itemArray)
+        {
+            [item.submenu makeDark];
+        }
+    }
+}
+
+@end
+
+@implementation NSMenuDarkMaker
+
+- (id)initWithMenu:(NSMenu *)menu;
+{
+    self = [super init];
+    if (self)
+    {
+        mMenu = menu;
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(beginTracking:)
+                                                     name:NSMenuDidBeginTrackingNotification object:mMenu];
+    }
+    return self;
+}
+
+- (void)dealloc;
+{
+    mMenu = nil;
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)beginTracking:(NSNotification *)note;
+{
+    [mMenu makeDark];
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMModals.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMModals.h
@@ -1,0 +1,18 @@
+//
+//  VMMModals.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 11/10/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface VMMModals : NSObject
+
++(NSWindow*)modalsWindow;
+
++(void)nextModalShouldRunOnWindow:(NSWindow*)window;
++(void)modalsShouldRunOnWindow:(NSWindow*)window whenCalledDuringBlock:(void (^) (void))block;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMModals.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMModals.m
@@ -1,0 +1,41 @@
+//
+//  VMMModals.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 11/10/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import "VMMModals.h"
+
+@implementation VMMModals
+
+static NSWindow* _alertsWindow;
+
+static NSWindow* _temporaryAlertsWindow;
+static int _temporaryCounter;
+
++(NSWindow*)modalsWindow
+{
+    if (_temporaryCounter > 0)
+    {
+        _temporaryCounter--;
+        return _temporaryAlertsWindow;
+    }
+    
+    return _alertsWindow;
+}
+
++(void)nextModalShouldRunOnWindow:(NSWindow*)window
+{
+    _temporaryCounter = 1;
+    _temporaryAlertsWindow = window;
+}
++(void)modalsShouldRunOnWindow:(NSWindow*)window whenCalledDuringBlock:(void (^) (void))block
+{
+    _alertsWindow = window;
+    block();
+    _alertsWindow = nil;
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMParentalControls.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMParentalControls.h
@@ -1,0 +1,36 @@
+//
+//  VMMUserAuthorization.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 05/02/2018.
+//  Copyright © 2018 VitorMM. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef enum VMMParentalControlsItunesGamesAgeRestriction
+{
+    VMMParentalControlsItunesGamesAgeRestrictionNone = 1000,
+    VMMParentalControlsItunesGamesAgeRestriction4    = 100,
+    VMMParentalControlsItunesGamesAgeRestriction9    = 200,
+    VMMParentalControlsItunesGamesAgeRestriction12   = 300,
+    VMMParentalControlsItunesGamesAgeRestriction17   = 600,
+} VMMParentalControlsItunesGamesAgeRestriction;
+
+
+@interface VMMParentalControls : NSObject
+
++(BOOL)isEnabled;
+
++(id)parentalControlsValueForAppWithDomain:(NSString*)appDomain keyName:(NSString*)keyName;
+
++(BOOL)iTunesMatureGamesAllowed;
++(VMMParentalControlsItunesGamesAgeRestriction)iTunesAgeRestrictionForGames;
+
++(BOOL)isAppRestrictionEnabled;
++(BOOL)isAppUseRestricted:(NSString*)appPath;
+
++(BOOL)isInternetUseRestricted;
++(BOOL)isWebsiteAllowed:(NSString*)websiteAddress;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMParentalControls.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMParentalControls.m
@@ -1,0 +1,147 @@
+//
+//  VMMUserAuthorization.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 05/02/2018.
+//  Copyright © 2018 VitorMM. All rights reserved.
+//
+
+#import "VMMParentalControls.h"
+
+#import "VMMPropertyList.h"
+
+#import "NSBundle+Extension.h"
+#import "NSString+Extension.h"
+#import "NSTask+Extension.h"
+
+static NSString* _Nonnull const VMMParentalControlsAppDomainItunes            = @"com.apple.iTunes";
+static NSString* _Nonnull const VMMParentalControlsAppDomainApplicationAccess = @"com.apple.applicationaccess.new";
+static NSString* _Nonnull const VMMParentalControlsAppDomainContentFilter     = @"com.apple.familycontrols.contentfilter";
+
+static NSString* _Nonnull const VMMParentalControlsItunesGamesAgeLimit                   = @"gamesLimit";
+static NSString* _Nonnull const VMMParentalControlsApplicationAccessFamilyControlEnabled = @"familyControlsEnabled";
+static NSString* _Nonnull const VMMParentalControlsApplicationAccessWhiteList            = @"whiteList";
+static NSString* _Nonnull const VMMParentalControlsContentFilterWhiteListEnabled         = @"whitelistEnabled";
+static NSString* _Nonnull const VMMParentalControlsContentFilterWhiteList                = @"siteWhitelist";
+static NSString* _Nonnull const VMMParentalControlsContentFilterBlackList                = @"filterBlacklist";
+
+static NSString* _Nonnull const VMMParentalControlsApplicationAccessWhiteListPath = @"path";
+static NSString* _Nonnull const VMMParentalControlsContentFilterWhiteListAddress  = @"address";
+
+@implementation VMMParentalControls
+
++(BOOL)isEnabled
+{
+    @autoreleasepool
+    {
+        NSString* dsclOutputString = [NSTask runProgram:@"dscl" withFlags:@[@".", @"mcxexport", NSHomeDirectory()]];
+        if (dsclOutputString == nil || dsclOutputString.length == 0) return FALSE;
+    }
+    
+    return TRUE;
+}
+
++(id)parentalControlsValueForAppWithDomain:(NSString*)appDomain keyName:(NSString*)keyName
+{
+    // Reference:
+    // https://real-world-systems.com/docs/dslocal.db.html
+    
+    @autoreleasepool
+    {
+        NSString* dsclOutputString = [NSTask runProgram:@"dscl" withFlags:@[@".", @"mcxexport", NSHomeDirectory(), appDomain, keyName]];
+        if (dsclOutputString == nil || dsclOutputString.length == 0) return nil;
+        
+        NSDictionary* dsclOutput = [VMMPropertyList propertyListWithArchivedString:dsclOutputString];
+        if (dsclOutput == nil || [dsclOutput isKindOfClass:[NSDictionary class]] == FALSE) return nil;
+        
+        NSDictionary* dict = dsclOutput[appDomain][keyName];
+        if (dict == nil) return nil;
+        
+        return dict[@"value"];
+    }
+}
+
++(BOOL)iTunesMatureGamesAllowed
+{
+    VMMParentalControlsItunesGamesAgeRestriction value = [self iTunesAgeRestrictionForGames];
+    return value == VMMParentalControlsItunesGamesAgeRestrictionNone ||
+           value == VMMParentalControlsItunesGamesAgeRestriction17;
+}
++(VMMParentalControlsItunesGamesAgeRestriction)iTunesAgeRestrictionForGames
+{
+    NSNumber* valueNumber = [self parentalControlsValueForAppWithDomain:VMMParentalControlsAppDomainItunes
+                                                                keyName:VMMParentalControlsItunesGamesAgeLimit];
+    if (valueNumber == nil || [valueNumber isKindOfClass:[NSNumber class]] == FALSE)
+        return VMMParentalControlsItunesGamesAgeRestrictionNone;
+    
+    NSInteger value = valueNumber.integerValue;
+    if (value == 0) return VMMParentalControlsItunesGamesAgeRestrictionNone;
+    
+    return (VMMParentalControlsItunesGamesAgeRestriction)value;
+}
+
++(BOOL)isAppRestrictionEnabled
+{
+    NSNumber* valueNumber = [self parentalControlsValueForAppWithDomain:VMMParentalControlsAppDomainApplicationAccess
+                                                                keyName:VMMParentalControlsApplicationAccessFamilyControlEnabled];
+    if (valueNumber == nil || [valueNumber isKindOfClass:[NSNumber class]] == FALSE) return FALSE;
+    
+    return valueNumber.boolValue;
+}
++(BOOL)isAppUseRestricted:(NSString*)appPath
+{
+    if ([self isAppRestrictionEnabled] == FALSE) return FALSE;
+    
+    NSArray* appsList = [self parentalControlsValueForAppWithDomain:VMMParentalControlsAppDomainApplicationAccess
+                                                            keyName:VMMParentalControlsApplicationAccessWhiteList];
+    
+    for (NSDictionary* itemApp in appsList)
+    {
+        NSString* itemAppPath = itemApp[VMMParentalControlsApplicationAccessWhiteListPath];
+        if ([itemAppPath isEqualToString:appPath]) return FALSE;
+    }
+    
+    return TRUE;
+}
+
++(BOOL)isInternetUseRestricted
+{
+    NSNumber* whiteListEnabled = [self parentalControlsValueForAppWithDomain:VMMParentalControlsAppDomainContentFilter
+                                                                     keyName:VMMParentalControlsContentFilterWhiteListEnabled];
+    if (whiteListEnabled == nil || [whiteListEnabled isKindOfClass:[NSNumber class]] == FALSE) return FALSE;
+    
+    return whiteListEnabled.boolValue;
+}
++(BOOL)isWebsiteAllowed:(NSString*)websiteAddress
+{
+    if ([self isInternetUseRestricted] == FALSE) return TRUE;
+    
+    NSArray* whiteList = [self parentalControlsValueForAppWithDomain:VMMParentalControlsAppDomainContentFilter
+                                                             keyName:VMMParentalControlsContentFilterWhiteList];
+    if (whiteList == nil || [whiteList isKindOfClass:[NSArray class]] == FALSE) return TRUE;
+    
+    NSArray* blackList = [self parentalControlsValueForAppWithDomain:VMMParentalControlsAppDomainContentFilter
+                                                             keyName:VMMParentalControlsContentFilterBlackList];
+    if (blackList == nil || [blackList isKindOfClass:[NSArray class]] == FALSE) return TRUE;
+    
+    for (NSString* blackListItemAddress in blackList)
+    {
+        if ([websiteAddress hasPrefix:blackListItemAddress])
+        {
+            return FALSE;
+        }
+    }
+    
+    for (NSDictionary* whiteListItem in whiteList)
+    {
+        NSString* whiteListItemAddress = whiteListItem[VMMParentalControlsContentFilterWhiteListAddress];
+        if (whiteListItemAddress != nil && [websiteAddress hasPrefix:whiteListItemAddress])
+        {
+            return TRUE;
+        }
+    }
+    
+    return FALSE;
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMPropertyList.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMPropertyList.h
@@ -1,0 +1,19 @@
+//
+//  VMMPropertyList.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 08/03/2018.
+//  Copyright © 2018 VitorMM. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface VMMPropertyList : NSObject
+
++(nullable id)propertyListWithUnarchivedString:(nonnull NSString*)string;
++(nullable id)propertyListWithUnarchivedData:(nonnull NSData*)data;
+
++(nullable id)propertyListWithArchivedString:(nonnull NSString *)string;
++(nullable id)propertyListWithArchivedData:(nonnull NSData *)data;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMPropertyList.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMPropertyList.m
@@ -1,0 +1,69 @@
+//
+//  VMMPropertyList.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 08/03/2018.
+//  Copyright © 2018 VitorMM. All rights reserved.
+//
+
+#import "VMMPropertyList.h"
+
+@implementation VMMPropertyList
+
++(nullable id)propertyListWithUnarchivedString:(nonnull NSString*)string
+{
+    id result;
+    
+    @autoreleasepool
+    {
+        NSData* data = [string dataUsingEncoding:NSUTF8StringEncoding];
+        result = [self propertyListWithUnarchivedData:data];
+    }
+    
+    return result;
+    
+}
++(nullable id)propertyListWithUnarchivedData:(nonnull NSData*)data
+{
+    id propertyList;
+    
+    @autoreleasepool
+    {
+        NSError *error;
+        NSPropertyListFormat format;
+        propertyList = [NSPropertyListSerialization propertyListWithData:data options:NSPropertyListImmutable
+                                                                  format:&format error:&error];
+        if (propertyList == nil || error != nil)
+        {
+            return nil;
+        }
+    }
+    
+    return propertyList;
+}
+
++(nullable id)propertyListWithArchivedString:(nonnull NSString *)string
+{
+    id result;
+    
+    @autoreleasepool
+    {
+        NSData* data = [string dataUsingEncoding:NSUTF8StringEncoding];
+        result = [self propertyListWithArchivedData:data];
+    }
+    
+    return result;
+}
++(nullable id)propertyListWithArchivedData:(nonnull NSData *)data
+{
+    @try
+    {
+        return [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    }
+    @catch (NSException* exception)
+    {
+        return nil;
+    }
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMTextFileView.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMTextFileView.h
@@ -1,0 +1,25 @@
+//
+//  VMMTextFileView.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 21/11/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface VMMTextFileView : NSTextView
+{
+    NSTimer *monitorTimer;
+    
+    NSString* _textFilePath;
+    NSStringEncoding _textFileEncoding;
+}
+
+@property (nonatomic, nullable) NSRunLoopMode runLoopMode;
+
+-(NSString* _Nullable)textFileContents;
+-(void)showTextFileAtPath:(nonnull NSString*)filePath withEncoding:(NSStringEncoding)encoding refreshingWithTimeInterval:(NSTimeInterval)interval;
+-(void)stopRefreshing;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMTextFileView.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMTextFileView.m
@@ -1,0 +1,83 @@
+//
+//  VMMTextFileView.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 21/11/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import "VMMTextFileView.h"
+
+#import "NSString+Extension.h"
+#import "NSText+Extension.h"
+#import "NSTimer+Extension.h"
+
+@implementation VMMTextFileView
+
+-(void)awakeFromNib
+{
+    _runLoopMode = NSDefaultRunLoopMode;
+}
+
+-(NSString* _Nullable)textFileContents
+{
+    if (_textFileEncoding == -1)
+    {
+        return [NSString stringWithContentsOfFile:_textFilePath];
+    }
+    
+    return [NSString stringWithContentsOfFile:_textFilePath encoding:_textFileEncoding];
+}
+-(void)reloadTextFileForTimer:(NSTimer*)timer
+{
+    NSString* wineLog = [self textFileContents];
+    NSRange priorSelectedRange = wineLog.length >= self.string.length ? self.selectedRange : NSMakeRange(0, 0);
+    [self deselectText];
+    
+    if (wineLog != nil)
+    {
+        @try
+        {
+            [self setString:wineLog];
+            [self setSelectedRange:priorSelectedRange];
+        }
+        @catch (NSException* exception)
+        {
+            [self setString:@""];
+            [self setSelectedRange:NSMakeRange(0, 0)];
+        }
+    }
+    
+    [self scrollToBottom];
+}
+-(void)startReloadingTextFileWithTimeInterval:(NSTimeInterval)interval
+{
+    [self setSelectedRangeAsTheBeginOfTheField];
+    [self setString:@""];
+    
+    monitorTimer = [NSTimer scheduledTimerWithRunLoopMode:_runLoopMode timeInterval:interval target:self
+                                                 selector:@selector(reloadTextFileForTimer:) userInfo:nil];
+}
+-(void)showTextFileAtPath:(nonnull NSString*)filePath withEncoding:(NSStringEncoding)encoding refreshingWithTimeInterval:(NSTimeInterval)interval
+{
+    _textFilePath = filePath;
+    _textFileEncoding = encoding;
+    
+    if (interval == 0)
+    {
+        [self reloadTextFileForTimer:nil];
+    }
+    else
+    {
+        [self startReloadingTextFileWithTimeInterval:interval];
+    }
+}
+-(void)stopRefreshing
+{
+    if (monitorTimer == nil) return;
+    
+    [monitorTimer invalidate];
+    [self reloadTextFileForTimer:nil];
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMUUID.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMUUID.h
@@ -1,0 +1,17 @@
+//
+//  VMMUUID.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 03/11/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NSString* _Nonnull VMMUUIDCreate(void);
+
+@interface VMMUUID : NSObject
+
++(nonnull NSString*)newUUIDString;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMUUID.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMUUID.m
@@ -1,0 +1,39 @@
+//
+//  VMMUUID.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 03/11/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import "VMMUUID.h"
+
+#import "VMMComputerInformation.h"
+
+NSString* _Nonnull VMMUUIDCreate(void)
+{
+    return [VMMUUID newUUIDString];
+}
+
+@implementation VMMUUID
+
++(nonnull NSString*)newUUIDString
+{
+    @autoreleasepool
+    {    
+        if (IsClassNSUUIDAvailable == false)
+        {
+            @autoreleasepool
+            {
+                CFUUIDRef udid = CFUUIDCreate(NULL);
+                NSString* newUUID = (NSString *) CFBridgingRelease(CFUUIDCreateString(NULL, udid));
+                CFRelease(udid);
+                return newUUID;
+            }
+        }
+        
+        return [[NSUUID UUID] UUIDString];
+    }
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMUsageKeycode.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMUsageKeycode.h
@@ -1,0 +1,276 @@
+//
+//  VMMUsageKeycode.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 09/08/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+//  Source:
+//  http://www.usb.org/developers/hidpage/Hut1_12v2.pdf (page 53)
+//
+//  Reference:
+//  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IOKit.framework/Versions/A/Headers/hid/IOHIDUsageTables.h
+//
+
+#import <Foundation/Foundation.h>
+
+@interface VMMUsageKeycode : NSObject
+
++(nonnull NSDictionary*)usageNamesByKeycode;
+
++(nullable NSString*)nameOfUsageKeycode:(uint32_t)key;
+
+@end
+
+enum {
+    // 00 Reserved
+    kKU_ErrorRollOver             = 0x01,
+    kKU_PostFail                  = 0x02,
+    kKU_ErrorUndefined            = 0x03,
+    
+    kKU_ANSI_A                    = 0x04,
+    kKU_ANSI_B                    = 0x05,
+    kKU_ANSI_C                    = 0x06,
+    kKU_ANSI_D                    = 0x07,
+    kKU_ANSI_E                    = 0x08,
+    kKU_ANSI_F                    = 0x09,
+    kKU_ANSI_G                    = 0x0A,
+    kKU_ANSI_H                    = 0x0B,
+    kKU_ANSI_I                    = 0x0C,
+    kKU_ANSI_J                    = 0x0D,
+    kKU_ANSI_K                    = 0x0E,
+    kKU_ANSI_L                    = 0x0F,
+    kKU_ANSI_M                    = 0x10,
+    kKU_ANSI_N                    = 0x11,
+    kKU_ANSI_O                    = 0x12,
+    kKU_ANSI_P                    = 0x13,
+    kKU_ANSI_Q                    = 0x14,
+    kKU_ANSI_R                    = 0x15,
+    kKU_ANSI_S                    = 0x16,
+    kKU_ANSI_T                    = 0x17,
+    kKU_ANSI_U                    = 0x18,
+    kKU_ANSI_V                    = 0x19,
+    kKU_ANSI_W                    = 0x1A,
+    kKU_ANSI_X                    = 0x1B,
+    kKU_ANSI_Y                    = 0x1C,
+    kKU_ANSI_Z                    = 0x1D,
+    
+    kKU_ANSI_1                    = 0x1E,
+    kKU_ANSI_2                    = 0x1F,
+    kKU_ANSI_3                    = 0x20,
+    kKU_ANSI_4                    = 0x21,
+    kKU_ANSI_5                    = 0x22,
+    kKU_ANSI_6                    = 0x23,
+    kKU_ANSI_7                    = 0x24,
+    kKU_ANSI_8                    = 0x25,
+    kKU_ANSI_9                    = 0x26,
+    kKU_ANSI_0                    = 0x27,
+    
+    kKU_Enter                     = 0x28, /* Mac calls it Return */
+    kKU_Escape                    = 0x29,
+    kKU_Delete                    = 0x2A, /* Backspace in Windows keyboards */
+    kKU_Tab                       = 0x2B,
+    kKU_Space                     = 0x2C,
+    kKU_ANSI_Minus                = 0x2D,
+    kKU_ANSI_Equal                = 0x2E,
+    kKU_ANSI_LeftBracket          = 0x2F,
+    kKU_ANSI_RightBracket         = 0x30,
+    kKU_ANSI_Backslash            = 0x31,
+    kKU_NonUSPound                = 0x32, /* Non-US # or _ */
+    kKU_ANSI_Semicolon            = 0x33,
+    kKU_ANSI_Quote                = 0x34,
+    kKU_ANSI_Grave                = 0x35,
+    kKU_ANSI_Comma                = 0x36,
+    kKU_ANSI_Period               = 0x37,
+    kKU_ANSI_Slash                = 0x38,
+    kKU_CapsLock                  = 0x39,
+    
+    kKU_F1                        = 0x3A,
+    kKU_F2                        = 0x3B,
+    kKU_F3                        = 0x3C,
+    kKU_F4                        = 0x3D,
+    kKU_F5                        = 0x3E,
+    kKU_F6                        = 0x3F,
+    kKU_F7                        = 0x40,
+    kKU_F8                        = 0x41,
+    kKU_F9                        = 0x42,
+    kKU_F10                       = 0x43,
+    kKU_F11                       = 0x44,
+    kKU_F12                       = 0x45,
+    
+    kKU_PrintScreen               = 0x46, // Not present in Mac virtual keycodes?
+    kKU_ScrollLock                = 0x47, // Not present in Mac virtual keycodes?
+    kKU_Pause                     = 0x48, // Not present in Mac virtual keycodes?
+    kKU_Insert                    = 0x49,
+    kKU_Home                      = 0x4A,
+    kKU_PageUp                    = 0x4B,
+    kKU_ForwardDelete             = 0x4C,
+    kKU_End                       = 0x4D,
+    kKU_PageDown                  = 0x4E,
+    kKU_RightArrow                = 0x4F,
+    kKU_LeftArrow                 = 0x50,
+    kKU_DownArrow                 = 0x51,
+    kKU_UpArrow                   = 0x52,
+    
+    kKU_ANSI_KeypadClear          = 0x53, /* This is also Num Lock */
+    kKU_ANSI_KeypadDivide         = 0x54,
+    kKU_ANSI_KeypadMultiply       = 0x55,
+    kKU_ANSI_KeypadMinus          = 0x56,
+    kKU_ANSI_KeypadPlus           = 0x57,
+    kKU_ANSI_KeypadEnter          = 0x58,
+    kKU_ANSI_Keypad1              = 0x59,
+    kKU_ANSI_Keypad2              = 0x5A,
+    kKU_ANSI_Keypad3              = 0x5B,
+    kKU_ANSI_Keypad4              = 0x5C,
+    kKU_ANSI_Keypad5              = 0x5D,
+    kKU_ANSI_Keypad6              = 0x5E,
+    kKU_ANSI_Keypad7              = 0x5F,
+    kKU_ANSI_Keypad8              = 0x60,
+    kKU_ANSI_Keypad9              = 0x61,
+    kKU_ANSI_Keypad0              = 0x62,
+    kKU_ANSI_KeypadDecimal        = 0x63,
+    kKU_NonUSBackslash            = 0x64,
+    kKU_Application               = 0x65, // Not present in Mac virtual keycodes?
+    kKU_Power                     = 0x66, // Maybe Menu in different keyboard? Wtf is menu? Have to check
+    kKU_ANSI_KeypadEquals         = 0x67,
+    
+    kKU_F13                       = 0x68,
+    kKU_F14                       = 0x69,
+    kKU_F15                       = 0x6A,
+    kKU_F16                       = 0x6B,
+    kKU_F17                       = 0x6C,
+    kKU_F18                       = 0x6D,
+    kKU_F19                       = 0x6E,
+    kKU_F20                       = 0x6F,
+    kKU_F21                       = 0x70,
+    kKU_F22                       = 0x71,
+    kKU_F23                       = 0x72,
+    kKU_F24                       = 0x73,
+    
+    kKU_Execute                   = 0x74, // Not present in Mac virtual keycodes?
+    kKU_Help                      = 0x75,
+    kKU_ContextMenu               = 0x76, /* That strange key next to Alt Gr in Windows keyboards */
+    kKU_Select                    = 0x77, // Not present in Mac virtual keycodes?
+    kKU_Stop                      = 0x78, // Not present in Mac virtual keycodes?
+    kKU_Again                     = 0x79, // Not present in Mac virtual keycodes?
+    kKU_Undo                      = 0x7A, // Not present in Mac virtual keycodes?
+    kKU_Cut                       = 0x7B, // Not present in Mac virtual keycodes?
+    kKU_Copy                      = 0x7C, // Not present in Mac virtual keycodes?
+    kKU_Paste                     = 0x7D, // Not present in Mac virtual keycodes?
+    kKU_Find                      = 0x7E, // Not present in Mac virtual keycodes?
+    kKU_Mute                      = 0x7F,
+    kKU_VolumeUp                  = 0x80,
+    kKU_VolumeDown                = 0x81,
+    kKU_Locking_CapsLock          = 0x82, // Not present in Mac virtual keycodes?
+    kKU_Locking_NumLock           = 0x83, // Not present in Mac virtual keycodes?
+    kKU_Locking_ScrollLock        = 0x84, // Not present in Mac virtual keycodes?
+    kKU_JIS_KeypadComma           = 0x85,
+    kKU_ANSI_KeypadEqual          = 0x86, // Not present in Mac virtual keycodes?
+    
+    kKU_InternationalKey1         = 0x87, // Not present in Mac virtual keycodes?
+    kKU_InternationalKey2         = 0x88, // Not present in Mac virtual keycodes?
+    kKU_JIS_Yen                   = 0x89,
+    kKU_InternationalKey4         = 0x8A, // Not present in Mac virtual keycodes?
+    kKU_InternationalKey5         = 0x8B, // Not present in Mac virtual keycodes?
+    kKU_InternationalKey6         = 0x8C, // Not present in Mac virtual keycodes?
+    kKU_InternationalKey7         = 0x8D, // Not present in Mac virtual keycodes?
+    kKU_InternationalKey8         = 0x8E, // Not present in Mac virtual keycodes?
+    kKU_InternationalKey9         = 0x8F, // Not present in Mac virtual keycodes?
+    
+    kKU_Toggle_HangulEnglish      = 0x90, // Not present in Mac virtual keycodes?
+    kKU_Conversion_Hanja          = 0x91, // Not present in Mac virtual keycodes?
+    kKU_Katakana                  = 0x92, // Not present in Mac virtual keycodes?
+    kKU_Hiragana                  = 0x93, // Not present in Mac virtual keycodes?
+    kKU_Zenkaku_Or_Hankaku        = 0x94, // Not present in Mac virtual keycodes?
+    kKU_LanguageSpecific1         = 0x95, // Not present in Mac virtual keycodes?
+    kKU_LanguageSpecific2         = 0x96, // Not present in Mac virtual keycodes?
+    kKU_LanguageSpecific3         = 0x97, // Not present in Mac virtual keycodes?
+    kKU_LanguageSpecific4         = 0x98, // Not present in Mac virtual keycodes?
+    
+    kKU_AltenateErase             = 0x99, // Not present in Mac virtual keycodes?
+    kKU_SysReq_Or_Attention       = 0x9A, // Not present in Mac virtual keycodes?
+    kKU_Cancel                    = 0x9B, // Not present in Mac virtual keycodes?
+    kKU_Clear                     = 0x9C, // Not present in Mac virtual keycodes?
+    kKU_Prior                     = 0x9D, // Not present in Mac virtual keycodes?
+    kKU_Return                    = 0x9E, // Not present in Mac virtual keycodes?
+    kKU_Separator                 = 0x9F, // Not present in Mac virtual keycodes?
+    kKU_Out                       = 0xA0, // Not present in Mac virtual keycodes?
+    kKU_Oper                      = 0xA1, // Not present in Mac virtual keycodes?
+    kKU_Clear_Or_Again            = 0xA2, // Not present in Mac virtual keycodes?
+    kKU_CrSel_Or_Props            = 0xA3, // Not present in Mac virtual keycodes?
+    kKU_ExSel                     = 0xA4, // Not present in Mac virtual keycodes?
+    
+    // A5 Reserved
+    // A6 Reserved
+    // A7 Reserved
+    // A8 Reserved
+    // A9 Reserved
+    // AA Reserved
+    // AB Reserved
+    // AC Reserved
+    // AD Reserved
+    // AE Reserved
+    // AF Reserved
+    
+    kKU_Keypad_ZeroZero           = 0xB0, // Not present in Mac virtual keycodes?
+    kKU_Keypad_ZeroZeroZero       = 0xB1, // Not present in Mac virtual keycodes?
+    kKU_Keypad_ThousandsSeparator = 0xB2, // Not present in Mac virtual keycodes? In US: ','
+    kKU_Keypad_DecimalSeparator   = 0xB3, // Not present in Mac virtual keycodes? In US: '.'
+    kKU_Keypad_CurrencyUnit       = 0xB4, // Not present in Mac virtual keycodes? In US: '$'
+    kKU_Keypad_CurrencySubunit    = 0xB5, // Not present in Mac virtual keycodes? In US: '¢'
+    kKU_Keypad_LeftParentheses    = 0xB6, // Not present in Mac virtual keycodes?
+    kKU_Keypad_RightParentheses   = 0xB7, // Not present in Mac virtual keycodes?
+    kKU_Keypad_LeftBraces         = 0xB8, // Not present in Mac virtual keycodes?
+    kKU_Keypad_RightBraces        = 0xB9, // Not present in Mac virtual keycodes?
+    kKU_Keypad_Tab                = 0xBA, // Not present in Mac virtual keycodes?
+    kKU_Keypad_Backspace          = 0xBB, // Not present in Mac virtual keycodes?
+    kKU_Keypad_A                  = 0xBC, // Not present in Mac virtual keycodes?
+    kKU_Keypad_B                  = 0xBD, // Not present in Mac virtual keycodes?
+    kKU_Keypad_C                  = 0xBE, // Not present in Mac virtual keycodes?
+    kKU_Keypad_D                  = 0xBF, // Not present in Mac virtual keycodes?
+    kKU_Keypad_E                  = 0xC0, // Not present in Mac virtual keycodes?
+    kKU_Keypad_F                  = 0xC1, // Not present in Mac virtual keycodes?
+    kKU_Keypad_XOR                = 0xC2, // Not present in Mac virtual keycodes?
+    kKU_Keypad_Circumflex         = 0xC3, // Not present in Mac virtual keycodes?
+    kKU_Keypad_Percent            = 0xC4, // Not present in Mac virtual keycodes?
+    kKU_Keypad_Less_Than          = 0xC5, // Not present in Mac virtual keycodes?
+    kKU_Keypad_More_Than          = 0xC6, // Not present in Mac virtual keycodes?
+    kKU_Keypad_Ampersand          = 0xC7, // Not present in Mac virtual keycodes?
+    kKU_Keypad_AmpersandAmpersand = 0xC8, // Not present in Mac virtual keycodes?
+    kKU_Keypad_VerticalLine       = 0xC9, // Not present in Mac virtual keycodes?
+    kKU_Keypad_TwoVerticalLines   = 0xCA, // Not present in Mac virtual keycodes?
+    kKU_Keypad_Colon              = 0xCB, // Not present in Mac virtual keycodes?
+    kKU_Keypad_NumberSign         = 0xCC, // Not present in Mac virtual keycodes?
+    kKU_Keypad_Space              = 0xCD, // Not present in Mac virtual keycodes?
+    kKU_Keypad_CommercialAt       = 0xCE, // Not present in Mac virtual keycodes?
+    kKU_Keypad_Exclamation        = 0xCF, // Not present in Mac virtual keycodes?
+    
+    kKU_Keypad_MemoryStore        = 0xD0, // Not present in Mac virtual keycodes?
+    kKU_Keypad_MemoryRecall       = 0xD1, // Not present in Mac virtual keycodes?
+    kKU_Keypad_MemoryClear        = 0xD2, // Not present in Mac virtual keycodes?
+    kKU_Keypad_MemoryAdd          = 0xD3, // Not present in Mac virtual keycodes?
+    kKU_Keypad_MemorySubstract    = 0xD4, // Not present in Mac virtual keycodes?
+    kKU_Keypad_MemoryMultiply     = 0xD5, // Not present in Mac virtual keycodes?
+    kKU_Keypad_MemoryDivide       = 0xD6, // Not present in Mac virtual keycodes?
+    kKU_Keypad_PlusMinus          = 0xD7, // Not present in Mac virtual keycodes?
+    kKU_Keypad_Clear              = 0xD8, // Not present in Mac virtual keycodes?
+    kKU_Keypad_ClearEntry         = 0xD9, // Not present in Mac virtual keycodes?
+    kKU_Keypad_Binary             = 0xDA, // Not present in Mac virtual keycodes?
+    kKU_Keypad_Octal              = 0xDB, // Not present in Mac virtual keycodes?
+    kKU_Keypad_Decimal            = 0xDC, // Not present in Mac virtual keycodes?
+    kKU_Keypad_Hexadecimal        = 0xDD, // Not present in Mac virtual keycodes?
+    
+    // DE Reserved
+    // DF Reserved
+    
+    kKU_LeftControl               = 0xE0,
+    kKU_LeftShift                 = 0xE1,
+    kKU_LeftOption                = 0xE2,
+    kKU_LeftCommand               = 0xE3,
+    kKU_RightControl              = 0xE4,
+    kKU_RightShift                = 0xE5,
+    kKU_RightOption               = 0xE6,
+    kKU_RightCommand              = 0xE7,
+    
+    // E8 ~ FFFF Reserved
+};

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMUsageKeycode.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMUsageKeycode.m
@@ -1,0 +1,279 @@
+//
+//  VMMUsageKeycode.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 09/08/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "VMMUsageKeycode.h"
+#import "VMMLocalizationUtility.h"
+
+@implementation VMMUsageKeycode
+
+NSDictionary* _usageNamesByKeycode;
+
++(nonnull NSDictionary*)usageNamesByKeycode
+{
+    if (!_usageNamesByKeycode)
+    {
+        _usageNamesByKeycode = @{
+                                 // 00 Reserved
+                                 @(kKU_ErrorRollOver):             VMMLocalizedString(@"Error Roll Over"),
+                                 @(kKU_PostFail):                  VMMLocalizedString(@"Post Fail"),
+                                 @(kKU_ErrorUndefined):            VMMLocalizedString(@"Error Undefined"),
+                                 @(kKU_ANSI_A):                    @"A",
+                                 @(kKU_ANSI_B):                    @"B",
+                                 @(kKU_ANSI_C):                    @"C",
+                                 @(kKU_ANSI_D):                    @"D",
+                                 @(kKU_ANSI_E):                    @"E",
+                                 @(kKU_ANSI_F):                    @"F",
+                                 @(kKU_ANSI_G):                    @"G",
+                                 @(kKU_ANSI_H):                    @"H",
+                                 @(kKU_ANSI_I):                    @"I",
+                                 @(kKU_ANSI_J):                    @"J",
+                                 @(kKU_ANSI_K):                    @"K",
+                                 @(kKU_ANSI_L):                    @"L",
+                                 @(kKU_ANSI_M):                    @"M",
+                                 @(kKU_ANSI_N):                    @"N",
+                                 @(kKU_ANSI_O):                    @"O",
+                                 @(kKU_ANSI_P):                    @"P",
+                                 @(kKU_ANSI_Q):                    @"Q",
+                                 @(kKU_ANSI_R):                    @"R",
+                                 @(kKU_ANSI_S):                    @"S",
+                                 @(kKU_ANSI_T):                    @"T",
+                                 @(kKU_ANSI_U):                    @"U",
+                                 @(kKU_ANSI_V):                    @"V",
+                                 @(kKU_ANSI_W):                    @"W",
+                                 @(kKU_ANSI_X):                    @"X",
+                                 @(kKU_ANSI_Y):                    @"Y",
+                                 @(kKU_ANSI_Z):                    @"Z",
+                                
+                                 @(kKU_ANSI_1):                    @"1",
+                                 @(kKU_ANSI_2):                    @"2",
+                                 @(kKU_ANSI_3):                    @"3",
+                                 @(kKU_ANSI_4):                    @"4",
+                                 @(kKU_ANSI_5):                    @"5",
+                                 @(kKU_ANSI_6):                    @"6",
+                                 @(kKU_ANSI_7):                    @"7",
+                                 @(kKU_ANSI_8):                    @"8",
+                                 @(kKU_ANSI_9):                    @"9",
+                                 @(kKU_ANSI_0):                    @"0",
+                                
+                                 @(kKU_Enter):                     VMMLocalizedString(@"Return"),
+                                 @(kKU_Escape):                    VMMLocalizedString(@"Escape"),
+                                 @(kKU_Delete):                    VMMLocalizedString(@"Delete"),
+                                 @(kKU_Tab):                       VMMLocalizedString(@"Tab"),
+                                 @(kKU_Space):                     VMMLocalizedString(@"Space"),
+                                 @(kKU_ANSI_Minus):                VMMLocalizedString(@"Minus"),
+                                 @(kKU_ANSI_Equal):                VMMLocalizedString(@"Equal"),
+                                 @(kKU_ANSI_LeftBracket):          VMMLocalizedString(@"Left Bracket"),
+                                 @(kKU_ANSI_RightBracket):         VMMLocalizedString(@"Right Bracket"),
+                                 @(kKU_ANSI_Backslash):            VMMLocalizedString(@"Backslash"),
+                                 @(kKU_NonUSPound):                VMMLocalizedString(@"Pound"),
+                                 @(kKU_ANSI_Semicolon):            VMMLocalizedString(@"Semicolon"),
+                                 @(kKU_ANSI_Quote):                VMMLocalizedString(@"Quote"),
+                                 @(kKU_ANSI_Grave):                VMMLocalizedString(@"Grave"),
+                                 @(kKU_ANSI_Comma):                VMMLocalizedString(@"Comma"),
+                                 @(kKU_ANSI_Period):               VMMLocalizedString(@"Period"),
+                                 @(kKU_ANSI_Slash):                VMMLocalizedString(@"Slash"),
+                                 @(kKU_CapsLock):                  VMMLocalizedString(@"Caps Lock"),
+                                
+                                 @(kKU_F1):                        @"F1",
+                                 @(kKU_F2):                        @"F2",
+                                 @(kKU_F3):                        @"F3",
+                                 @(kKU_F4):                        @"F4",
+                                 @(kKU_F5):                        @"F5",
+                                 @(kKU_F6):                        @"F6",
+                                 @(kKU_F7):                        @"F7",
+                                 @(kKU_F8):                        @"F8",
+                                 @(kKU_F9):                        @"F9",
+                                 @(kKU_F10):                       @"F10",
+                                 @(kKU_F11):                       @"F11",
+                                 @(kKU_F12):                       @"F12",
+                                
+                                 @(kKU_PrintScreen):               VMMLocalizedString(@"Print Screen"),
+                                 @(kKU_ScrollLock):                VMMLocalizedString(@"Scroll Lock"),
+                                 @(kKU_Pause):                     VMMLocalizedString(@"Pause"),
+                                 @(kKU_Insert):                    VMMLocalizedString(@"Insert"),
+                                 @(kKU_Home):                      VMMLocalizedString(@"Home"),
+                                 @(kKU_PageUp):                    VMMLocalizedString(@"Page Up"),
+                                 @(kKU_ForwardDelete):             VMMLocalizedString(@"Forward Delete"),
+                                 @(kKU_End):                       VMMLocalizedString(@"End"),
+                                 @(kKU_PageDown):                  VMMLocalizedString(@"Page Down"),
+                                 @(kKU_RightArrow):                VMMLocalizedString(@"Right Arrow"),
+                                 @(kKU_LeftArrow):                 VMMLocalizedString(@"Left Arrow"),
+                                 @(kKU_DownArrow):                 VMMLocalizedString(@"Down Arrow"),
+                                 @(kKU_UpArrow):                   VMMLocalizedString(@"Up Arrow"),
+                                
+                                 @(kKU_ANSI_KeypadClear):          VMMLocalizedString(@"Keypad Clear"),
+                                 @(kKU_ANSI_KeypadDivide):         VMMLocalizedString(@"Keypad Divide"),
+                                 @(kKU_ANSI_KeypadMultiply):       VMMLocalizedString(@"Keypad Multiply"),
+                                 @(kKU_ANSI_KeypadMinus):          VMMLocalizedString(@"Keypad Minus"),
+                                 @(kKU_ANSI_KeypadPlus):           VMMLocalizedString(@"Keypad Plus"),
+                                 @(kKU_ANSI_KeypadEnter):          VMMLocalizedString(@"Keypad Enter"),
+                                 @(kKU_ANSI_Keypad1):              VMMLocalizedString(@"Keypad 1"),
+                                 @(kKU_ANSI_Keypad2):              VMMLocalizedString(@"Keypad 2"),
+                                 @(kKU_ANSI_Keypad3):              VMMLocalizedString(@"Keypad 3"),
+                                 @(kKU_ANSI_Keypad4):              VMMLocalizedString(@"Keypad 4"),
+                                 @(kKU_ANSI_Keypad5):              VMMLocalizedString(@"Keypad 5"),
+                                 @(kKU_ANSI_Keypad6):              VMMLocalizedString(@"Keypad 6"),
+                                 @(kKU_ANSI_Keypad7):              VMMLocalizedString(@"Keypad 7"),
+                                 @(kKU_ANSI_Keypad8):              VMMLocalizedString(@"Keypad 8"),
+                                 @(kKU_ANSI_Keypad9):              VMMLocalizedString(@"Keypad 9"),
+                                 @(kKU_ANSI_Keypad0):              VMMLocalizedString(@"Keypad 0"),
+                                 @(kKU_ANSI_KeypadDecimal):        VMMLocalizedString(@"Keypad Decimal"),
+                                 @(kKU_NonUSBackslash):            VMMLocalizedString(@"Backslash"),
+                                 @(kKU_Application):               VMMLocalizedString(@"Application"),
+                                 @(kKU_Power):                     VMMLocalizedString(@"Power"),
+                                 @(kKU_ANSI_KeypadEquals):         VMMLocalizedString(@"Keypad Equals"),
+                                
+                                 @(kKU_F13):                       @"F13",
+                                 @(kKU_F14):                       @"F14",
+                                 @(kKU_F15):                       @"F15",
+                                 @(kKU_F16):                       @"F16",
+                                 @(kKU_F17):                       @"F17",
+                                 @(kKU_F18):                       @"F18",
+                                 @(kKU_F19):                       @"F19",
+                                 @(kKU_F20):                       @"F20",
+                                 @(kKU_F21):                       @"F21",
+                                 @(kKU_F22):                       @"F22",
+                                 @(kKU_F23):                       @"F23",
+                                 @(kKU_F24):                       @"F24",
+                                
+                                 @(kKU_Execute):                   VMMLocalizedString(@"Execute"),
+                                 @(kKU_Help):                      VMMLocalizedString(@"Help"),
+                                 @(kKU_ContextMenu ):              VMMLocalizedString(@"Context Menu"),
+                                 @(kKU_Select):                    VMMLocalizedString(@"Select"),
+                                 @(kKU_Stop):                      VMMLocalizedString(@"Stop"),
+                                 @(kKU_Again):                     VMMLocalizedString(@"Again"),
+                                 @(kKU_Undo):                      VMMLocalizedString(@"Undo"),
+                                 @(kKU_Cut):                       VMMLocalizedString(@"Cut"),
+                                 @(kKU_Copy):                      VMMLocalizedString(@"Copy"),
+                                 @(kKU_Paste):                     VMMLocalizedString(@"Paste"),
+                                 @(kKU_Find):                      VMMLocalizedString(@"Find"),
+                                 @(kKU_Mute):                      VMMLocalizedString(@"Mute"),
+                                 @(kKU_VolumeUp):                  VMMLocalizedString(@"Volume Up"),
+                                 @(kKU_VolumeDown):                VMMLocalizedString(@"Volume Down"),
+                                 @(kKU_Locking_CapsLock):          VMMLocalizedString(@"Locking Caps Lock"),
+                                 @(kKU_Locking_NumLock):           VMMLocalizedString(@"Locking Num Lock"),
+                                 @(kKU_Locking_ScrollLock):        VMMLocalizedString(@"Locking Scroll Lock"),
+                                 @(kKU_JIS_KeypadComma):           VMMLocalizedString(@"Keypad Comma"),
+                                 @(kKU_ANSI_KeypadEqual):          VMMLocalizedString(@"Keypad Equal"),
+                                
+                                 @(kKU_InternationalKey1):         @"",
+                                 @(kKU_InternationalKey2):         @"",
+                                 @(kKU_JIS_Yen):                   @"Yen",
+                                 @(kKU_InternationalKey4):         @"",
+                                 @(kKU_InternationalKey5):         @"",
+                                 @(kKU_InternationalKey6):         @"",
+                                 @(kKU_InternationalKey7):         @"",
+                                 @(kKU_InternationalKey8):         @"",
+                                 @(kKU_InternationalKey9):         @"",
+                                
+                                 @(kKU_Toggle_HangulEnglish):      VMMLocalizedString(@"Hangul/English"),
+                                 @(kKU_Conversion_Hanja):          VMMLocalizedString(@"Conversion Hanja"),
+                                 @(kKU_Katakana):                  @"Katakana",
+                                 @(kKU_Hiragana):                  @"Hiragana",
+                                 @(kKU_Zenkaku_Or_Hankaku):        VMMLocalizedString(@"Zankaku or Hankaku"),
+                                 @(kKU_LanguageSpecific1):         @"",
+                                 @(kKU_LanguageSpecific2):         @"",
+                                 @(kKU_LanguageSpecific3):         @"",
+                                 @(kKU_LanguageSpecific4):         @"",
+                                
+                                 @(kKU_AltenateErase):             VMMLocalizedString(@"Alternate Erase"),
+                                 @(kKU_SysReq_Or_Attention):       VMMLocalizedString(@"SysReq or Attention"),
+                                 @(kKU_Cancel):                    VMMLocalizedString(@"Cancel"),
+                                 @(kKU_Clear):                     VMMLocalizedString(@"Clear"),
+                                 @(kKU_Prior):                     VMMLocalizedString(@"Prior"),
+                                 @(kKU_Return):                    VMMLocalizedString(@"Return"),
+                                 @(kKU_Separator):                 VMMLocalizedString(@"Separator"),
+                                 @(kKU_Out):                       VMMLocalizedString(@"Out"),
+                                 @(kKU_Oper):                      VMMLocalizedString(@"Oper"),
+                                 @(kKU_Clear_Or_Again):            VMMLocalizedString(@"Clear or Again"),
+                                 @(kKU_CrSel_Or_Props):            VMMLocalizedString(@"CrSel or Props"),
+                                 @(kKU_ExSel):                     VMMLocalizedString(@"ExSel"),
+                                
+                                 // A5 Reserved
+                                 // A6 Reserved
+                                 // A7 Reserved
+                                 // A8 Reserved
+                                 // A9 Reserved
+                                 // AA Reserved
+                                 // AB Reserved
+                                 // AC Reserved
+                                 // AD Reserved
+                                 // AE Reserved
+                                 // AF Reserved
+                                
+                                 @(kKU_Keypad_ZeroZero):           VMMLocalizedString(@"Keypad Zero Zero"),
+                                 @(kKU_Keypad_ZeroZeroZero):       VMMLocalizedString(@"Keypad Zero Zero Zero"),
+                                 @(kKU_Keypad_ThousandsSeparator): VMMLocalizedString(@"Keypad Thousands Separator"),
+                                 @(kKU_Keypad_DecimalSeparator):   VMMLocalizedString(@"Keypad Decimal Separator"),
+                                 @(kKU_Keypad_CurrencyUnit):       VMMLocalizedString(@"Keypad Currency Unit"),
+                                 @(kKU_Keypad_CurrencySubunit):    VMMLocalizedString(@"Keypad Currency Subunit"),
+                                 @(kKU_Keypad_LeftParentheses):    VMMLocalizedString(@"Keypad Left Parentheses"),
+                                 @(kKU_Keypad_RightParentheses):   VMMLocalizedString(@"Keypad Right Parentheses"),
+                                 @(kKU_Keypad_LeftBraces):         VMMLocalizedString(@"Keypad Left Braces"),
+                                 @(kKU_Keypad_RightBraces):        VMMLocalizedString(@"Keypad Right Braces"),
+                                 @(kKU_Keypad_Tab):                VMMLocalizedString(@"Keypad Tab"),
+                                 @(kKU_Keypad_Backspace):          VMMLocalizedString(@"Keypad Backspace"),
+                                 @(kKU_Keypad_A):                  VMMLocalizedString(@"Keypad A"),
+                                 @(kKU_Keypad_B):                  VMMLocalizedString(@"Keypad B"),
+                                 @(kKU_Keypad_C):                  VMMLocalizedString(@"Keypad C"),
+                                 @(kKU_Keypad_D):                  VMMLocalizedString(@"Keypad D"),
+                                 @(kKU_Keypad_E):                  VMMLocalizedString(@"Keypad E"),
+                                 @(kKU_Keypad_F):                  VMMLocalizedString(@"Keypad F"),
+                                 @(kKU_Keypad_XOR):                VMMLocalizedString(@"Keypad XOR"),
+                                 @(kKU_Keypad_Circumflex):         VMMLocalizedString(@"Keypad Circumflex"),
+                                 @(kKU_Keypad_Percent):            VMMLocalizedString(@"Keypad Percent"),
+                                 @(kKU_Keypad_Less_Than):          VMMLocalizedString(@"Keypad Less Than"),
+                                 @(kKU_Keypad_More_Than):          VMMLocalizedString(@"Keypad More Than"),
+                                 @(kKU_Keypad_Ampersand):          VMMLocalizedString(@"Keypad Ampersand"),
+                                 @(kKU_Keypad_AmpersandAmpersand): VMMLocalizedString(@"Keypad Ampersand Ampersand"),
+                                 @(kKU_Keypad_VerticalLine):       VMMLocalizedString(@"Keypad Vertical Line"),
+                                 @(kKU_Keypad_TwoVerticalLines):   VMMLocalizedString(@"Keypad Two Vertical Lines"),
+                                 @(kKU_Keypad_Colon):              VMMLocalizedString(@"Keypad Colon"),
+                                 @(kKU_Keypad_NumberSign):         VMMLocalizedString(@"Keypad Number Sign"),
+                                 @(kKU_Keypad_Space):              VMMLocalizedString(@"Keypad Space"),
+                                 @(kKU_Keypad_CommercialAt):       VMMLocalizedString(@"Keypad Commercial At"),
+                                 @(kKU_Keypad_Exclamation):        VMMLocalizedString(@"Keypad Exclamation"),
+                                
+                                 @(kKU_Keypad_MemoryStore):        VMMLocalizedString(@"Keypad Memory Store"),
+                                 @(kKU_Keypad_MemoryRecall):       VMMLocalizedString(@"Keypad Memory Recall"),
+                                 @(kKU_Keypad_MemoryClear):        VMMLocalizedString(@"Keypad Memory Clear"),
+                                 @(kKU_Keypad_MemoryAdd):          VMMLocalizedString(@"Keypad Memory Add"),
+                                 @(kKU_Keypad_MemorySubstract):    VMMLocalizedString(@"Keypad Memory Substract"),
+                                 @(kKU_Keypad_MemoryMultiply):     VMMLocalizedString(@"Keypad Memory Multiply"),
+                                 @(kKU_Keypad_MemoryDivide):       VMMLocalizedString(@"Keypad Memory Divide"),
+                                 @(kKU_Keypad_PlusMinus):          VMMLocalizedString(@"Keypad Plus Minus"),
+                                 @(kKU_Keypad_Clear):              VMMLocalizedString(@"Keypad Clear"),
+                                 @(kKU_Keypad_ClearEntry):         VMMLocalizedString(@"Keypad Clear Entry"),
+                                 @(kKU_Keypad_Binary):             VMMLocalizedString(@"Keypad Binary"),
+                                 @(kKU_Keypad_Octal):              VMMLocalizedString(@"Keypad Octal"),
+                                 @(kKU_Keypad_Decimal):            VMMLocalizedString(@"Keypad Decimal"),
+                                 @(kKU_Keypad_Hexadecimal):        VMMLocalizedString(@"Keypad Hexadecimal"),
+                                 // DE ~ DF Reserved
+                                
+                                 @(kKU_LeftControl):               VMMLocalizedString(@"Left Control"),
+                                 @(kKU_LeftShift):                 VMMLocalizedString(@"Left Shift"),
+                                 @(kKU_LeftOption):                VMMLocalizedString(@"Left Option"),
+                                 @(kKU_LeftCommand):               VMMLocalizedString(@"Left Command"),
+                                 @(kKU_RightControl):              VMMLocalizedString(@"Right Control"),
+                                 @(kKU_RightShift):                VMMLocalizedString(@"Right Shift"),
+                                 @(kKU_RightOption):               VMMLocalizedString(@"Right Option"),
+                                 @(kKU_RightCommand):              VMMLocalizedString(@"Right Command"),
+                                
+                                 // E8 ~ FFFF Reserved
+                                };
+    }
+    
+    return _usageNamesByKeycode;
+}
++(nullable NSString*)nameOfUsageKeycode:(uint32_t)key
+{
+    NSString* name = self.usageNamesByKeycode[@(key)];
+    return (name && name.length > 0) ? name : nil;
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMUserNotificationCenter.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMUserNotificationCenter.h
@@ -1,0 +1,36 @@
+//
+//  VMMUserNotificationCenter.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef enum {
+    VMMUserNotificationNormal                = 0,
+    VMMUserNotificationOnlyWithAction        = 1 << 0,
+    VMMUserNotificationPreferGrowl           = 1 << 1,
+    VMMUserNotificationNoAlert               = 1 << 2
+    
+} VMMUserNotificationCenterOptions;
+
+@protocol VMMUserNotificationCenterDelegate
+-(void)actionButtonPressedForNotificationWithUserInfo:(nullable NSObject*)userInfo;
+@end
+
+@interface VMMUserNotificationCenter : NSObject
+
+@property (nonatomic, nullable) id<VMMUserNotificationCenterDelegate> delegate;
+
++(nonnull instancetype)defaultUserNotificationCenter;
+
++(BOOL)isGrowlAvailable;
++(BOOL)isNSUserNotificationCenterAvailable;
+
+-(BOOL)deliverNotificationWithTitle:(nullable NSString*)title message:(nullable NSString*)message userInfo:(nullable NSObject*)info icon:(nullable NSImage*)icon actionButtonText:(nullable NSString*)actionButton options:(VMMUserNotificationCenterOptions)options;
+
+-(BOOL)deliverNotificationWithTitle:(nullable NSString*)title message:(nullable NSString*)message icon:(nullable NSImage*)icon options:(VMMUserNotificationCenterOptions)options;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMUserNotificationCenter.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMUserNotificationCenter.m
@@ -1,0 +1,242 @@
+//
+//  VMMUserNotificationCenter.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 22/02/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+//  Reference:
+//  https://github.com/indragiek/NSUserNotificationPrivate
+//
+//  Growl support with Applescript:
+//  http://growl.info/documentation/applescript-support.php
+//  TODO: Check if Growl support is working
+//
+
+#import "VMMUserNotificationCenter.h"
+
+#import "VMMComputerInformation.h"
+
+#import "VMMAlert.h"
+#import "NSArray+Extension.h"
+#import "NSBundle+Extension.h"
+#import "NSFileManager+Extension.h"
+#import "NSImage+Extension.h"
+#import "VMMUUID.h"
+
+#import "ObjCExtensionConfig.h"
+
+static NSString* const NOTIFICATION_UTILITY_SHARED_DICTIONARY_KEY = @"info";
+
+@interface NSUserNotification (NSUserNotificationPrivate)
+
+@property(readonly, nonatomic) NSData *_identityImageData;
+- (void)_setIdentityImage:(id)arg1 withIdentifier:(id)arg2;
+
+@property(copy) NSImage *_identityImage;
+@property BOOL _identityImageHasBorder;
+
+@end
+
+@implementation VMMUserNotificationCenter
+
+static VMMUserNotificationCenter *_sharedInstance;
+
++(nonnull instancetype)defaultUserNotificationCenter
+{
+    @synchronized([self class])
+    {
+        if (!_sharedInstance)
+        {
+            _sharedInstance = [[VMMUserNotificationCenter alloc] init];
+        }
+        return _sharedInstance;
+    }
+}
+
+-(BOOL)userNotificationCenter:(id)center shouldPresentNotification:(id)notification
+{
+    return YES;
+}
+-(void)userNotificationCenter:(id)center didActivateNotification:(id)notification
+{
+    if (self.delegate != nil)
+    {
+        NSDictionary* userInfoDict = ((NSUserNotification *)notification).userInfo;
+        NSObject* userInfo = userInfoDict[NOTIFICATION_UTILITY_SHARED_DICTIONARY_KEY];
+        [self.delegate actionButtonPressedForNotificationWithUserInfo:userInfo];
+    }
+}
+
+
++(BOOL)isGrowlAvailable
+{
+    NSArray<NSRunningApplication*>* apps = [[NSWorkspace sharedWorkspace] runningApplications];
+    for (NSRunningApplication* app in apps) {
+        if ([app.bundleIdentifier isEqualToString:@"com.Growl.GrowlHelperApp"]) return true;
+    }
+    return false;
+}
++(BOOL)isNSUserNotificationCenterAvailable
+{
+    return IsClassNSUserNotificationCenterAvailable;
+}
+
+
+-(BOOL)deliverGrowlNotificationWithTitle:(nullable NSString*)title message:(nullable NSString*)message icon:(nullable NSImage*)icon
+{
+    BOOL sent = false;
+    
+    @autoreleasepool
+    {
+        NSURL* iconFileUrl;
+        BOOL doesGrowlSupportImageFromLocation = (IS_SYSTEM_MAC_OS_10_7_OR_SUPERIOR == false);
+        BOOL useIcon = doesGrowlSupportImageFromLocation && (icon != nil);
+        
+        if (useIcon)
+        {
+            NSString* iconFilePath = [NSString stringWithFormat:@"%@growlTemp%@.png",NSTemporaryDirectory(),VMMUUIDCreate()];
+            [icon writeToFile:iconFilePath atomically:YES];
+            iconFileUrl = [NSURL fileURLWithPath:iconFilePath];
+        }
+        
+        NSString* appName = [[NSBundle originalMainBundle] bundleName];
+        NSArray* growlScript = @[                           @"tell application id \"com.Growl.GrowlHelperApp\"",
+                                                            @"\tset the allNotificationsList to {\"Notification\"}",
+                                                            @"\tset the enabledNotificationsList to {\"Notification\"}",
+                                                            @"\tregister as application ¬",
+                                 [NSString stringWithFormat:@"\t\t\"%@\" all notifications allNotificationsList ¬",appName],
+                                                            @"\t\tdefault notifications enabledNotificationsList ¬",
+                                 [NSString stringWithFormat:@"\t\ticon of application \"%@\"",appName],
+                                                            @"\t",
+                                                            @"\tnotify with ¬",
+                                                            @"\t\tname \"Notification\"  ¬",
+                (title != nil) ? [NSString stringWithFormat:@"\t\ttitle \"%@\"  ¬",title] : @"\t\t¬",
+              (message != nil) ? [NSString stringWithFormat:@"\t\tdescription \"%@\"  ¬",message] : @"\t\t¬",
+                                 [NSString stringWithFormat:@"\t\tapplication name \"%@\" ¬",appName],
+                     (useIcon) ? [NSString stringWithFormat:@"\t\timage from location \"%@\"",iconFileUrl.absoluteString] : @"\t\t",
+                                                            @"end tell"];
+        NSAppleScript* notification = [[NSAppleScript alloc] initWithSource:[growlScript componentsJoinedByString:@"\n"]];
+        NSAppleEventDescriptor* notificationSent = [notification executeAndReturnError:nil];
+        sent = (notificationSent != nil);
+    }
+    
+    return sent;
+}
+-(void)deliverNativeNotificationWithTitle:(nullable NSString*)title message:(nullable NSString*)message userInfo:(nullable NSObject*)info icon:(nullable NSImage*)icon actionButtonText:(nullable NSString*)actionButton
+{
+    [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:(id<NSUserNotificationCenterDelegate>)self];
+    
+    NSUserNotification *notification = [[NSUserNotification alloc] init];
+    notification.title = title;
+    notification.informativeText = message;
+    notification.soundName = NSUserNotificationDefaultSoundName;
+    notification.userInfo = info ? @{NOTIFICATION_UTILITY_SHARED_DICTIONARY_KEY:info} : @{};
+
+    if (icon != nil)
+    {
+        #if USER_NOTIFICATIONS_SHOULD_SHOW_A_BIGGER_ICON == TRUE
+            @try
+            {
+                [notification setValue:icon   forKey:@"_identityImage"];
+                [notification setValue:@FALSE forKey:@"_identityImageHasBorder"];
+            }
+            @catch (NSException* exception)
+            {
+                // Avoiding API exception in case something changes in the future
+                
+                // That feature is only available from macOS 10.9 and beyond
+                if ([notification respondsToSelector:@selector(setContentImage:)])
+                {
+                    notification.contentImage = icon;
+                }
+            }
+        #else
+            // That feature is only available from macOS 10.9 and beyond
+            if ([notification respondsToSelector:@selector(setContentImage:)])
+            {
+                notification.contentImage = icon;
+            }
+        #endif
+    }
+    
+    if (actionButton != nil)
+    {
+        [notification setHasActionButton:YES];
+        [notification setActionButtonTitle:actionButton];
+    }
+    
+    [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+}
+
+
+-(BOOL)deliverNotificationWithTitle:(nullable NSString*)title message:(nullable NSString*)message userInfo:(nullable NSObject*)info icon:(nullable NSImage*)icon actionButtonText:(nullable NSString*)actionButton options:(VMMUserNotificationCenterOptions)options
+{
+    BOOL hasUserNotificationCenter = [VMMUserNotificationCenter isNSUserNotificationCenterAvailable];
+    BOOL hasGrowl = [VMMUserNotificationCenter isGrowlAvailable];
+    BOOL allowAlert = !(options | VMMUserNotificationNoAlert);
+    BOOL preferGrowl = (options | VMMUserNotificationPreferGrowl);
+    BOOL allowNotificationWithNoAction = !(options | VMMUserNotificationOnlyWithAction);
+    
+    // Growl (preference)
+    if (hasGrowl && preferGrowl && allowNotificationWithNoAction)
+    {
+        BOOL success = [self deliverGrowlNotificationWithTitle:title message:message icon:icon];
+        if (success) return TRUE;
+    }
+    
+    // NSUserNotificationCenter
+    if (hasUserNotificationCenter)
+    {
+        [self deliverNativeNotificationWithTitle:title message:message userInfo:info icon:icon actionButtonText:actionButton];
+        return TRUE;
+    }
+    
+    // Growl (not preference)
+    if (hasGrowl && !preferGrowl && allowNotificationWithNoAction)
+    {
+        BOOL success = [self deliverGrowlNotificationWithTitle:title message:message icon:icon];
+        if (success) return TRUE;
+    }
+    
+    // NSAlert
+    if (allowAlert)
+    {
+        // NSAlert (with action)
+        if (actionButton != nil && self.delegate != nil)
+        {
+            BOOL runAction = [VMMAlert confirmationDialogWithTitle:title message:message andSettings:^(VMMAlert *alert)
+            {
+                [alert.buttons.firstObject setTitle:actionButton];
+                [alert setIcon:icon];
+            }];
+            
+            if (runAction)
+            {
+                [self.delegate actionButtonPressedForNotificationWithUserInfo:info];
+            }
+            
+            return TRUE;
+        }
+        
+        // NSAlert (with no action)
+        if (allowNotificationWithNoAction)
+        {
+            [VMMAlert showAlertWithTitle:title message:message andSettings:^(VMMAlert *alert)
+            {
+                [alert setIcon:icon];
+            }];
+            
+            return TRUE;
+        }
+    }
+    
+    return FALSE;
+}
+
+-(BOOL)deliverNotificationWithTitle:(nullable NSString*)title message:(nullable NSString*)message icon:(nullable NSImage*)icon options:(VMMUserNotificationCenterOptions)options
+{
+    return [self deliverNotificationWithTitle:title message:message userInfo:nil icon:icon actionButtonText:nil options:options];
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMVersion.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMVersion.h
@@ -1,0 +1,27 @@
+//
+//  VMMVersion.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 18/09/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef enum VMMVersionCompare
+{
+    VMMVersionCompareFirstIsNewest,
+    VMMVersionCompareSecondIsNewest,
+    VMMVersionCompareSame
+} VMMVersionCompare;
+
+@interface VMMVersion : NSObject
+
+@property (nonatomic, strong) NSArray<NSString*>* _Nonnull components;
+
+-(nonnull instancetype)initWithString:(nonnull NSString*)string;
+-(VMMVersionCompare)compareWithVersion:(nonnull VMMVersion*)version;
+
++(VMMVersionCompare)compareVersionString:(nonnull NSString*)PK1 withVersionString:(nonnull NSString*)PK2;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMVersion.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMVersion.m
@@ -1,0 +1,61 @@
+//
+//  VMMVersion.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 18/09/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "VMMVersion.h"
+
+#import "NSString+Extension.h"
+
+@implementation VMMVersion
+
+-(nonnull instancetype)initWithString:(nonnull NSString*)string
+{
+    self = [super init];
+    if (self)
+    {
+        self.components = [string componentsSeparatedByString:@"."];
+    }
+    return self;
+}
+-(VMMVersionCompare)compareWithVersion:(nonnull VMMVersion*)version
+{
+    @autoreleasepool
+    {
+        NSArray<NSString*>* PKArray1 = self.components;
+        NSArray<NSString*>* PKArray2 = version.components;
+        
+        for (int x = 0; x < PKArray1.count && x < PKArray2.count; x++)
+        {
+            if ([PKArray1[x] initialIntegerValue].intValue < [PKArray2[x] initialIntegerValue].intValue)
+                return VMMVersionCompareSecondIsNewest;
+            
+            if ([PKArray1[x] initialIntegerValue].intValue > [PKArray2[x] initialIntegerValue].intValue)
+                return VMMVersionCompareFirstIsNewest;
+            
+            if (PKArray1[x].length > PKArray2[x].length) return VMMVersionCompareFirstIsNewest;
+            if (PKArray1[x].length < PKArray2[x].length) return VMMVersionCompareSecondIsNewest;
+        }
+        
+        if (PKArray1.count < PKArray2.count) return VMMVersionCompareSecondIsNewest;
+        if (PKArray1.count > PKArray2.count) return VMMVersionCompareFirstIsNewest;
+        
+        return VMMVersionCompareSame;
+    }
+}
+
++(VMMVersionCompare)compareVersionString:(nonnull NSString*)PK1 withVersionString:(nonnull NSString*)PK2
+{
+    @autoreleasepool
+    {
+        VMMVersion* version1 = [[VMMVersion alloc] initWithString:PK1];
+        VMMVersion* version2 = [[VMMVersion alloc] initWithString:PK2];
+        
+        return [version1 compareWithVersion:version2];
+    }
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMVideoCard.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMVideoCard.h
@@ -1,0 +1,143 @@
+//
+//  VMMVideoCard.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 18/03/18.
+//  Copyright © 2018 VitorMM. All rights reserved.
+//
+//  References:
+//  https://lists.denx.de/pipermail/u-boot/2015-May/215147.html
+//
+
+#import <Foundation/Foundation.h>
+#import "VMMComputerInformation.h"
+
+static NSString * _Nonnull const VMMVideoCardModelNameKey =                  @"sppci_model";
+static NSString * _Nonnull const VMMVideoCardChipsetNameKey =                @"_name";
+static NSString * _Nonnull const VMMVideoCardDeviceTypeKey =                 @"sppci_device_type";      // eg. 'GPU'
+static NSString * _Nonnull const VMMVideoCardBusKey =                        @"sppci_bus";              // eg. VMMVideoCardBusPCIe
+static NSString * _Nonnull const VMMVideoCardMemorySizeBuiltInAlternateKey = @"_spdisplays_vram";       // eg. '1536 MB'
+static NSString * _Nonnull const VMMVideoCardMemorySizeBuiltInKey =          @"spdisplays_vram_shared"; // eg. '1536 MB'
+static NSString * _Nonnull const VMMVideoCardMemorySizePciOrPcieKey =        @"spdisplays_vram";        // eg. '1536 MB'
+static NSString * _Nonnull const VMMVideoCardVendorIDKey =                   @"spdisplays_vendor-id";   // eg. '0x8086'
+static NSString * _Nonnull const VMMVideoCardVendorKey =                     @"spdisplays_vendor";
+static NSString * _Nonnull const VMMVideoCardDeviceIDKey =                   @"spdisplays_device-id";   // eg. '0x0046'
+static NSString * _Nonnull const VMMVideoCardMetalSupportKey =               @"spdisplays_metal";
+static NSString * _Nonnull const VMMVideoCardKextInfoKey =                   @"sppci_kextinfo"; // eg. 'sppci_kextnotloaded'
+
+static NSString * _Nonnull const VMMVideoCardKextInfoNotLoaded =  @"sppci_kextnotloaded";
+
+static NSString * _Nonnull const VMMVideoCardTypeApple =           @"Apple Silicon";
+static NSString * _Nonnull const VMMVideoCardTypeIntelHD =         @"Intel HD";
+static NSString * _Nonnull const VMMVideoCardTypeIntelUHD =        @"Intel UHD";
+static NSString * _Nonnull const VMMVideoCardTypeIntelIris =       @"Intel Iris";
+static NSString * _Nonnull const VMMVideoCardTypeIntelIrisPro =    @"Intel Iris Pro";
+static NSString * _Nonnull const VMMVideoCardTypeIntelIrisPlus =   @"Intel Iris Plus";
+static NSString * _Nonnull const VMMVideoCardTypeIntelGMA =        @"Intel GMA";
+static NSString * _Nonnull const VMMVideoCardTypeIntelCoffeeLake = @"Intel Coffee Lake";
+static NSString * _Nonnull const VMMVideoCardTypeATIAMD =          @"ATI/AMD";
+static NSString * _Nonnull const VMMVideoCardTypeNVIDIA =          @"NVIDIA";
+
+static NSString * _Nonnull const VMMVideoCardDeviceTypeGPU  = @"spdisplays_gpu";
+static NSString * _Nonnull const VMMVideoCardDeviceTypeeGPU = @"spdisplays_egpu";
+
+static NSString * _Nonnull const VMMVideoCardBusPCIe =        @"spdisplays_pcie_device";
+static NSString * _Nonnull const VMMVideoCardBusPCI =         @"sppci_pci_device";
+static NSString * _Nonnull const VMMVideoCardBusBuiltIn =     @"spdisplays_builtin";
+
+static NSString * _Nonnull const VMMVideoCardVendorIDApple =  @"0x05ac";
+static NSString * _Nonnull const VMMVideoCardVendorIDIntel =  @"0x8086";
+static NSString * _Nonnull const VMMVideoCardVendorIDNVIDIA = @"0x10de";
+static NSString * _Nonnull const VMMVideoCardVendorIDATIAMD = @"0x1002";
+
+static NSString * _Nonnull const VMMVideoCardVendorApple =    @"Apple";
+static NSString * _Nonnull const VMMVideoCardVendorIntel =    @"Intel";
+static NSString * _Nonnull const VMMVideoCardVendorNVIDIA =   @"NVIDIA";
+static NSString * _Nonnull const VMMVideoCardVendorATIAMD =   @"ATI/AMD";
+
+static NSString * _Nonnull const VMMVideoCardNameVirtualBox =                 @"VirtualBox VM";
+static NSString * _Nonnull const VMMVideoCardTypeVirtualBox =                 @"VirtualBox";
+static NSString * _Nonnull const VMMVideoCardVendorVirtualBox =               @"VirtualBox";
+static NSString * _Nonnull const VMMVideoCardVendorIDVirtualBox =             @"0x80ee";
+static NSString * _Nonnull const VMMVideoCardDeviceIDVirtualBox =             @"0xbeef";
+
+static NSString * _Nonnull const VMMVideoCardNameVMware =                     @"VMware VM";
+static NSString * _Nonnull const VMMVideoCardTypeVMware =                     @"VMware";
+static NSString * _Nonnull const VMMVideoCardVendorVMware =                   @"VMware";
+static NSString * _Nonnull const VMMVideoCardVendorIDVMware =                 @"0x15ad";
+
+static NSString * _Nonnull const VMMVideoCardNameParallelsDesktop =           @"Parallels Desktop VM";
+static NSString * _Nonnull const VMMVideoCardTypeParallelsDesktop =           @"Parallels Desktop";
+static NSString * _Nonnull const VMMVideoCardVendorParallelsDesktop =         @"Parallels Desktop";
+static NSString * _Nonnull const VMMVideoCardVendorIDParallelsDesktop =       @"0x1ab8";
+
+static NSString * _Nonnull const VMMVideoCardNameMicrosoftRemoteDesktop =     @"Microsoft Remote Desktop";
+static NSString * _Nonnull const VMMVideoCardTypeMicrosoftRemoteDesktop =     @"Microsoft Remote Desktop";
+static NSString * _Nonnull const VMMVideoCardVendorMicrosoftRemoteDesktop =   @"Microsoft Remote Desktop";
+static NSString * _Nonnull const VMMVideoCardVendorIDMicrosoftRemoteDesktop = @"0xbaad";
+
+static NSString * _Nonnull const VMMVideoCardNameQemu =                       @"QEMU Emulated Graphic Card";
+static NSString * _Nonnull const VMMVideoCardTypeQemu =                       @"QEMU";
+static NSString * _Nonnull const VMMVideoCardVendorQemu =                     @"QEMU";
+static NSString * _Nonnull const VMMVideoCardVendorIDQemu =                   @"0x1234";
+static NSString * _Nonnull const VMMVideoCardDeviceIDQemu =                   @"0x1111";
+
+
+static NSString * _Nonnull const VMMVideoCardDeviceIDIntelHDGraphics =     @"0x0046";
+static NSString * _Nonnull const VMMVideoCardDeviceIDIntelHDGraphics3000 = @"0x0116";
+static NSString * _Nonnull const VMMVideoCardDeviceIDIntelHDGraphics4000 = @"0x0166";
+static NSString * _Nonnull const VMMVideoCardDeviceIDNVIDIAGeForce9400M =  @"0x0863";
+
+static NSString * _Nonnull const VMMVideoCardDeviceIDNVIDIAGeForce320M_1 = @"0x08a0";
+static NSString * _Nonnull const VMMVideoCardDeviceIDNVIDIAGeForce320M_2 = @"0x08a2";
+static NSString * _Nonnull const VMMVideoCardDeviceIDNVIDIAGeForce320M_3 = @"0x08a3";
+static NSString * _Nonnull const VMMVideoCardDeviceIDNVIDIAGeForce320M_4 = @"0x08a4";
+static NSString * _Nonnull const VMMVideoCardDeviceIDNVIDIAGeForce320M_5 = @"0x08a5";
+
+static NSInteger const VMMVideoCardMemoryMinimumSize = 64;
+
+static NSString * _Nonnull const VMMVideoCardTemporaryKeyIOServiceValues      = @"RawRegIOServiceValues";
+static NSString * _Nonnull const VMMVideoCardTemporaryKeyOpenGlApiMemorySizes = @"temp_memory_size_opengl_api_values";
+
+@interface VMMVideoCard : NSObject
+{
+    NSLock* _Nullable nameLock;
+    NSLock* _Nullable typeLock;
+    NSLock* _Nullable busLock;
+    NSLock* _Nullable deviceIDLock;
+    NSLock* _Nullable vendorIDLock;
+    NSLock* _Nullable vendorLock;
+    NSLock* _Nullable memorySizeInMegabytesLock;
+}
+
+-(instancetype _Nullable )initVideoCardWithDictionary:(NSDictionary* _Nonnull)dict;
+
+@property (nonatomic, strong, readonly) NSDictionary* _Nonnull dictionary;
+
+@property (nonatomic, strong, readonly) NSString* _Nullable modelName;
+@property (nonatomic, strong, readonly) NSString* _Nullable chipsetName;
+@property (nonatomic, strong, readonly) NSString* _Nullable type;
+@property (nonatomic, strong, readonly) NSString* _Nullable bus;
+@property (nonatomic, strong, readonly) NSString* _Nullable deviceID;
+@property (nonatomic, strong, readonly) NSString* _Nullable vendorID;
+@property (nonatomic, strong, readonly) NSString* _Nullable vendor;
+@property (nonatomic, strong, readonly) NSNumber* _Nullable memorySizeInMegabytes;
+
+-(BOOL)kextLoaded;
+
+-(BOOL)isExternalGpu;
+
+-(BOOL)supportsMetal;
+-(VMMMetalFeatureSet)metalFeatureSet;
+
+-(NSString* _Nonnull)descriptiveName;
+-(NSString* _Nonnull)veryDescriptiveName;
+
+-(BOOL)hasRealVendorID;
+-(BOOL)isComplete;
+-(BOOL)isVirtualMachineVideoCard;
+
+-(BOOL)isSameVideoCard:(nonnull VMMVideoCard*)vc;
+-(void)mergeWithIOPCIVideoCard:(nonnull VMMVideoCard*)vc;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMVideoCard.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMVideoCard.m
@@ -1,0 +1,915 @@
+//
+//  VMMVideoCard.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 18/03/18.
+//  Copyright © 2018 VitorMM. All rights reserved.
+//
+//  TODO: May be a good adition in the future:
+//  https://github.com/codykrieger/gfxCardStatus
+//
+
+
+
+#import "VMMVideoCard.h"
+#import "ObjCExtensionConfig.h"
+#import "NSString+Extension.h"
+#import "NSMutableString+Extension.h"
+#import "VMMVideoCardManager.h"
+
+#if IM_IMPORTING_THE_OPENGL_FRAMEWORK == true
+    #import <OpenGL/OpenGL.h>
+#else
+    #import <dlfcn.h>
+    #import "VMMLogUtility.h"
+
+    #define kCGLRPVideoMemoryMegabytes 131
+    #define kCGLRPVideoMemory          120
+
+    struct _CGLRendererInfoObject {};
+    typedef struct _CGLRendererInfoObject  *CGLRendererInfoObj;
+
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wstrict-prototypes"
+    typedef void* (*arbitrary)();
+    #pragma clang diagnostic pop
+#endif
+
+@implementation VMMVideoCard
+
+@synthesize dictionary = _dictionary;
+@synthesize modelName = _modelName;
+@synthesize chipsetName = _chipsetName;
+@synthesize type = _type;
+@synthesize bus = _bus;
+@synthesize deviceID = _deviceID;
+@synthesize vendorID = _vendorID;
+@synthesize vendor = _vendor;
+@synthesize memorySizeInMegabytes = _memorySizeInMegabytes;
+
+-(instancetype)initVideoCardWithDictionary:(NSDictionary*)dict
+{
+    self = [super init];
+    if (self)
+    {
+        NSMutableDictionary* newDict = [dict mutableCopy];
+        
+        // The if below only exists for testing purposes, in case you want to override that value
+        if (newDict[VMMVideoCardTemporaryKeyOpenGlApiMemorySizes] == nil)
+        {
+            #if USE_THE_OPENGL_FRAMEWORK_WHEN_AVAILABLE == true || IM_IMPORTING_THE_OPENGL_FRAMEWORK == true
+                newDict[VMMVideoCardTemporaryKeyOpenGlApiMemorySizes] = [VMMVideoCard videoCardMemorySizesInMegabytesFromOpenGLAPI];
+            #else
+                newDict[VMMVideoCardTemporaryKeyOpenGlApiMemorySizes] = @[];
+            #endif
+        }
+        
+        _dictionary = newDict;
+        
+        nameLock                  = [[NSLock alloc] init];
+        typeLock                  = [[NSLock alloc] init];
+        busLock                   = [[NSLock alloc] init];
+        deviceIDLock              = [[NSLock alloc] init];
+        vendorIDLock              = [[NSLock alloc] init];
+        vendorLock                = [[NSLock alloc] init];
+        memorySizeInMegabytesLock = [[NSLock alloc] init];
+    }
+    return self;
+}
+
++(nullable NSString*)typeForVideoCardWithName:(NSString*)videoCardName
+{
+    NSString* graphicCardName = [videoCardName uppercaseString];
+    if (graphicCardName == nil) return nil;
+    
+    NSCharacterSet* charactersThatShouldBecomeSpaces = [NSCharacterSet characterSetWithCharactersInString:@"(),"];
+    graphicCardName = [graphicCardName stringByReplacingCharactersInSet:charactersThatShouldBecomeSpaces withString:@" "];
+    NSArray<NSString*>* graphicCardNameComponents = [graphicCardName componentsSeparatedByString:@" "];
+    
+    if ([graphicCardNameComponents containsObject:@"INTEL"])
+    {
+        if ([graphicCardNameComponents containsObject:@"HD"])   return VMMVideoCardTypeIntelHD;
+        if ([graphicCardNameComponents containsObject:@"IRIS"]) {
+            if ([graphicCardNameComponents containsObject:@"PRO"])  return VMMVideoCardTypeIntelIrisPro;
+            if ([graphicCardNameComponents containsObject:@"PLUS"]) return VMMVideoCardTypeIntelIrisPlus;
+            return VMMVideoCardTypeIntelIris;
+        }
+        if ([graphicCardNameComponents containsObject:@"COFFEE"] && [graphicCardNameComponents containsObject:@"LAKE"]) {
+            return VMMVideoCardTypeIntelCoffeeLake;
+        }
+        
+        for (NSString* component in graphicCardNameComponents)
+        {
+            if ([component hasPrefix:@"GM"] && [[component substringFromIndex:2] intValue] != 0) return VMMVideoCardTypeIntelGMA;
+        }
+    }
+    
+    for (NSString* model in @[@"AMD",@"ATI",@"RADEON"])
+    {
+        if ([graphicCardNameComponents containsObject:model]) return VMMVideoCardTypeATIAMD;
+    }
+    
+    for (NSString* model in @[@"NVIDIA",@"GEFORCE",@"NVS",@"QUADRO"])
+    {
+        if ([graphicCardNameComponents containsObject:model]) return VMMVideoCardTypeNVIDIA;
+    }
+    
+    if ([graphicCardNameComponents containsObject:@"GMA"]) return VMMVideoCardTypeIntelGMA;
+    if ([graphicCardNameComponents containsObject:@"UHD"]) return VMMVideoCardTypeIntelUHD;
+    
+    return nil;
+}
+
+#if IM_IMPORTING_THE_OPENGL_FRAMEWORK == true
++(NSArray<NSNumber*>*)videoCardMemorySizesInMegabytesFromOpenGLAPI
+{
+    // Reference:
+    // https://developer.apple.com/library/content/qa/qa1168/_index.html
+    
+    GLint i, nrend = 0;
+    GLint videoMemory = 0;
+    const GLint displayMask = 0xFFFFFFFF;
+    NSMutableArray<NSNumber*>* list = [[NSMutableArray alloc] init];
+    
+    CGLRendererInfoObj rend;
+    CGLQueryRendererInfo((GLuint)displayMask, &rend, &nrend);
+    for (i = 0; i < nrend; i++)
+    {
+        videoMemory = 0;
+        CGLDescribeRenderer(rend, i, (IS_SYSTEM_MAC_OS_10_7_OR_SUPERIOR ? kCGLRPVideoMemoryMegabytes : kCGLRPVideoMemory), &videoMemory);
+        if (videoMemory != 0) [list addObject:@(videoMemory)];
+    }
+    CGLDestroyRendererInfo(rend);
+    
+    [list sortUsingComparator:^NSComparisonResult(NSNumber*  _Nonnull obj1, NSNumber*  _Nonnull obj2) {
+        NSInteger value1 = obj1.integerValue;
+        NSInteger value2 = obj2.integerValue;
+        if (value1 > value2) return NSOrderedAscending;
+        if (value1 < value2) return NSOrderedDescending;
+        return NSOrderedSame;
+    }];
+    return list;
+}
+#else
+#if USE_THE_OPENGL_FRAMEWORK_WHEN_AVAILABLE == true
++(NSArray<NSNumber*>*)videoCardMemorySizesInMegabytesFromOpenGLAPI
+{
+    NSMutableArray<NSNumber*>* list = [[NSMutableArray alloc] init];
+    
+    @autoreleasepool
+    {
+        // Loading a framework dinamically is not trivial... References:
+        // Loading Objective-C Class:   https://stackoverflow.com/a/24266440/4370893
+        // Loading C int function:      https://stackoverflow.com/a/21375580/4370893
+        // Loading C/C++ void function: https://stackoverflow.com/a/1354569/4370893
+        
+        void *openglFramework = dlopen("System/Library/Frameworks/OpenGL.framework/OpenGL", RTLD_NOW);
+        if (!openglFramework) return @[];
+        
+        int32_t i, nrend = 0;
+        int32_t videoMemory = 0;
+        const int32_t displayMask = 0xFFFFFFFF;
+        
+        CGLRendererInfoObj rend;
+        
+        arbitrary queryRendererInfo;
+        *(void**)(&queryRendererInfo) = dlsym(openglFramework, "CGLQueryRendererInfo");
+        arbitrary describeRenderer;
+        *(void**)(&describeRenderer) = dlsym(openglFramework, "CGLDescribeRenderer");
+        arbitrary destroyRendererInfo;
+        *(void**)(&destroyRendererInfo) = dlsym(openglFramework, "CGLDestroyRendererInfo");
+        
+        queryRendererInfo((uint32_t)displayMask, &rend, &nrend);
+        for (i = 0; i < nrend; i++)
+        {
+            videoMemory = 0;
+            describeRenderer(rend, i, (IS_SYSTEM_MAC_OS_10_7_OR_SUPERIOR ? kCGLRPVideoMemoryMegabytes : kCGLRPVideoMemory), &videoMemory);
+            if (videoMemory != 0) [list addObject:@(videoMemory)];
+        }
+        destroyRendererInfo(rend);
+        
+        if (0 != dlclose(openglFramework)) {
+            NSDebugLog(@"dlclose failed! %s\n", dlerror());
+        }
+    }
+    
+    [list sortUsingComparator:^NSComparisonResult(NSNumber*  _Nonnull obj1, NSNumber*  _Nonnull obj2) {
+        NSInteger value1 = obj1.integerValue;
+        NSInteger value2 = obj2.integerValue;
+        if (value1 > value2) return NSOrderedAscending;
+        if (value1 < value2) return NSOrderedDescending;
+        return NSOrderedSame;
+    }];
+    return list;
+}
+#endif
+#endif
+
+-(NSString*)vendorIDFromVendorAndVendorIDKeysOnly
+{
+    NSDictionary* localVideoCard = _dictionary;
+    
+    NSString* localVendorID = localVideoCard[VMMVideoCardVendorIDKey];
+    if (localVendorID != nil)
+    {
+        return localVendorID;
+    }
+    
+    NSString* localVendor = localVideoCard[VMMVideoCardVendorKey]; // eg. 'NVIDIA (0x10de)' or 'sppci_vendor_Nvidia'
+    if (localVendor == nil)
+    {
+        return nil;
+    }
+    
+    if ([localVendor contains:@"("])
+    {
+        return [localVendor getFragmentAfter:@"(" andBefore:@")"];
+    }
+    
+    if ([localVendor hasPrefix:@"sppci_vendor_"])
+    {
+        localVendor = [localVendor stringByReplacingOccurrencesOfString:@"sppci_vendor_" withString:@""];
+        localVendor = localVendor.uppercaseString;
+        
+        if ([localVendor contains:@"APPLE"])
+        {
+            return VMMVideoCardVendorIDApple;
+        }
+        if ([localVendor contains:@"NVIDIA"])
+        {
+            return VMMVideoCardVendorIDNVIDIA;
+        }
+        if ([localVendor contains:@"ATI"] || [localVendor contains:@"AMD"])
+        {
+            return VMMVideoCardVendorIDATIAMD;
+        }
+        if ([localVendor contains:@"INTEL"])
+        {
+            return VMMVideoCardVendorIDIntel;
+        }
+    }
+    
+    return nil;
+}
+-(nullable NSString*)deviceID
+{
+    @synchronized(deviceIDLock)
+    {
+        if (_deviceID != nil)
+        {
+            return _deviceID;
+        }
+        
+        @autoreleasepool
+        {
+            _deviceID = [_dictionary[VMMVideoCardDeviceIDKey] lowercaseString];
+            return _deviceID;
+        }
+    }
+}
+-(nullable NSString*)bus
+{
+    @synchronized(busLock)
+    {
+        if (_bus != nil)
+        {
+            return _bus;
+        }
+        
+        _bus = _dictionary[VMMVideoCardBusKey];
+        return _bus;
+    }
+}
+
++(NSString*)validateVideoCardName:(NSString*)name {
+    if (name == nil) return nil;
+    if (![name isKindOfClass:[NSString class]]) return nil;
+    
+    NSMutableString* trimName = [name mutableCopy];
+    [trimName trim];
+    
+    // Generic video card names
+    if ([trimName isEqualToString:@"Display"]) return nil;
+    if ([trimName isEqualToString:@"spdisplays_display"]) return nil;
+    
+    // Still don't know why that happens... but that happens
+    if ([trimName isEqualToString:@"Apple WiFi card"]) return nil;
+    
+    // NVIDIA video card wasn't properly detected and enabled by macOS
+    if ([trimName isEqualToString:@"NVIDIA Chip Model"]) return nil;
+    if ([trimName isEqualToString:@"nVidia GeForce XXXXXXXXXXX"]) return nil;
+    
+    // AMD video card wasn't properly detected and enabled by macOS
+    if ([trimName isEqualToString:@"AMD R9 xxx"]) return nil;
+    if ([trimName matchesWithRegex:@"AMD Radeon HD [6-8]xxx"]) return nil;
+    
+    return trimName;
+}
+-(void)loadModelNameAndChipsetName
+{
+    @synchronized(nameLock)
+    {
+        if (_modelName != nil || _chipsetName != nil)
+        {
+            return;
+        }
+        
+        @autoreleasepool
+        {
+            NSString* videoCardName = _dictionary[VMMVideoCardModelNameKey];
+            NSString* chipsetModel  = _dictionary[VMMVideoCardChipsetNameKey];
+            
+            _modelName   = [VMMVideoCard validateVideoCardName:videoCardName];
+            _chipsetName = [VMMVideoCard validateVideoCardName:chipsetModel];
+            
+            if (_modelName == nil && _chipsetName != nil)
+            {
+                _modelName = _chipsetName;
+            }
+            
+            if (_modelName != nil)
+            {
+                return;
+            }
+            
+            NSString* vendorID = [self vendorIDFromVendorAndVendorIDKeysOnly];
+            
+            if (vendorID != nil)
+            {
+                NSString* deviceID = [self deviceID];
+                
+                if ([vendorID isEqualToString:VMMVideoCardVendorIDVirtualBox] &&
+                    [deviceID isEqualToString:VMMVideoCardDeviceIDVirtualBox])
+                {
+                    videoCardName = VMMVideoCardNameVirtualBox;
+                }
+                
+                if ([vendorID isEqualToString:VMMVideoCardVendorIDVMware])
+                {
+                    videoCardName = VMMVideoCardNameVMware;
+                }
+                
+                if ([vendorID isEqualToString:VMMVideoCardVendorIDParallelsDesktop])
+                {
+                    videoCardName = VMMVideoCardNameParallelsDesktop;
+                }
+                
+                if ([vendorID isEqualToString:VMMVideoCardVendorIDMicrosoftRemoteDesktop])
+                {
+                    videoCardName = VMMVideoCardNameMicrosoftRemoteDesktop;
+                }
+                
+                if ([vendorID isEqualToString:VMMVideoCardVendorIDQemu] &&
+                    [deviceID isEqualToString:VMMVideoCardDeviceIDQemu])
+                {
+                    videoCardName = VMMVideoCardNameQemu;
+                }
+            }
+            
+            // TODO: Maybe this link can be used in the future to improve detection of the name
+            // http://pci-ids.ucw.cz/
+            
+            _modelName = videoCardName;
+        }
+    }
+}
+-(nullable NSString*)modelName
+{
+    [self loadModelNameAndChipsetName];
+    return _modelName == nil ? _chipsetName : _modelName;
+}
+-(nullable NSString*)chipsetName
+{
+    [self loadModelNameAndChipsetName];
+    return _chipsetName;
+}
+
+-(nullable NSString*)type
+{
+    @synchronized(typeLock)
+    {
+        if (_type != nil)
+        {
+            return _type;
+        }
+        
+        @autoreleasepool
+        {
+            NSString* videoCardType = [VMMVideoCard typeForVideoCardWithName:self.modelName];
+            if (videoCardType != nil)
+            {
+                _type = videoCardType;
+                return _type;
+            }
+            
+            NSString* localVendorID = [self vendorIDFromVendorAndVendorIDKeysOnly];
+            
+            NSDictionary* vendorIDType = @{
+               VMMVideoCardVendorIDApple:                  VMMVideoCardTypeApple,
+               VMMVideoCardVendorIDATIAMD:                 VMMVideoCardTypeATIAMD,
+               VMMVideoCardVendorIDNVIDIA:                 VMMVideoCardTypeNVIDIA,
+               VMMVideoCardVendorIDVirtualBox:             VMMVideoCardTypeVirtualBox,
+               VMMVideoCardVendorIDVMware:                 VMMVideoCardTypeVMware,
+               VMMVideoCardVendorIDParallelsDesktop:       VMMVideoCardTypeParallelsDesktop,
+               VMMVideoCardVendorIDMicrosoftRemoteDesktop: VMMVideoCardTypeMicrosoftRemoteDesktop,
+               VMMVideoCardVendorIDQemu:                   VMMVideoCardTypeQemu };
+            
+            _type = vendorIDType[localVendorID];
+        }
+        
+        return _type;
+    }
+    
+    return nil;
+}
+
+-(nullable NSString*)vendorID
+{
+    @synchronized(vendorIDLock)
+    {
+        if (_vendorID != nil)
+        {
+            return _vendorID;
+        }
+        
+        @autoreleasepool
+        {
+            NSString* localVendorID = [self vendorIDFromVendorAndVendorIDKeysOnly];
+            if (localVendorID != nil)
+            {
+                if ([@[VMMVideoCardVendorIDApple,
+                       VMMVideoCardVendorIDIntel,
+                       VMMVideoCardVendorIDATIAMD,
+                       VMMVideoCardVendorIDNVIDIA,
+                       VMMVideoCardVendorIDVirtualBox,
+                       VMMVideoCardVendorIDVMware,
+                       VMMVideoCardVendorIDParallelsDesktop,
+                       VMMVideoCardVendorIDQemu,
+                       VMMVideoCardVendorIDMicrosoftRemoteDesktop] containsObject:localVendorID])
+                {
+                    _vendorID = localVendorID;
+                    return _vendorID;
+                }
+                
+                // If the Vendor ID doesn't match with any of the above, it's a Hackintosh, using a fake video card vendor ID
+                // https://www.tonymacx86.com/threads/problem-with-hd4000-graphics-only-3mb-ram-showing.242113/
+                
+                return nil;
+            }
+            
+            NSString* videoCardType = self.type;
+            if (videoCardType != nil)
+            {
+                if ([@[VMMVideoCardTypeApple] containsObject:videoCardType])
+                {
+                    _vendorID = VMMVideoCardVendorIDApple; // Apple Vendor ID
+                    return _vendorID;
+                }
+                
+                if ([@[VMMVideoCardTypeIntelIris,
+                       VMMVideoCardTypeIntelIrisPro,
+                       VMMVideoCardTypeIntelIrisPlus,
+                       VMMVideoCardTypeIntelHD,
+                       VMMVideoCardTypeIntelUHD,
+                       VMMVideoCardTypeIntelGMA,
+                       VMMVideoCardTypeIntelCoffeeLake] containsObject:videoCardType])
+                {
+                    _vendorID = VMMVideoCardVendorIDIntel; // Intel Vendor ID
+                    return _vendorID;
+                }
+                
+                if ([@[VMMVideoCardTypeATIAMD] containsObject:videoCardType])
+                {
+                    _vendorID = VMMVideoCardVendorIDATIAMD; // ATI/AMD Vendor ID
+                    return _vendorID;
+                }
+                
+                if ([@[VMMVideoCardTypeNVIDIA] containsObject:videoCardType])
+                {
+                    _vendorID = VMMVideoCardVendorIDNVIDIA; // NVIDIA Vendor ID
+                    return _vendorID;
+                }
+            }
+            
+            return nil;
+        }
+    }
+}
+-(NSString*)vendor
+{
+    @synchronized(vendorLock)
+    {
+        if (_vendor != nil)
+        {
+            return _vendor;
+        }
+        
+        @autoreleasepool
+        {
+            NSString* vendorID = self.vendorID;
+            
+            if ([vendorID isEqualToString:VMMVideoCardVendorIDApple])
+            {
+                _vendor = VMMVideoCardVendorApple;
+                return _vendor;
+            }
+            
+            if ([vendorID isEqualToString:VMMVideoCardVendorIDIntel])
+            {
+                _vendor = VMMVideoCardVendorIntel;
+                return _vendor;
+            }
+            
+            if ([vendorID isEqualToString:VMMVideoCardVendorIDNVIDIA])
+            {
+                _vendor = VMMVideoCardVendorNVIDIA;
+                return _vendor;
+            }
+            
+            if ([vendorID isEqualToString:VMMVideoCardVendorIDATIAMD])
+            {
+                _vendor = VMMVideoCardVendorATIAMD;
+                return _vendor;
+            }
+            
+            if ([vendorID isEqualToString:VMMVideoCardVendorIDVirtualBox])
+            {
+                _vendor = VMMVideoCardVendorVirtualBox;
+                return _vendor;
+            }
+            
+            if ([vendorID isEqualToString:VMMVideoCardVendorIDVMware])
+            {
+                _vendor = VMMVideoCardVendorVMware;
+                return _vendor;
+            }
+            
+            if ([vendorID isEqualToString:VMMVideoCardVendorIDParallelsDesktop])
+            {
+                _vendor = VMMVideoCardVendorParallelsDesktop;
+                return _vendor;
+            }
+            
+            if ([vendorID isEqualToString:VMMVideoCardVendorIDMicrosoftRemoteDesktop])
+            {
+                _vendor = VMMVideoCardVendorMicrosoftRemoteDesktop;
+                return _vendor;
+            }
+            
+            if ([vendorID isEqualToString:VMMVideoCardVendorIDQemu])
+            {
+                _vendor = VMMVideoCardVendorQemu;
+                return _vendor;
+            }
+            
+            return nil;
+        }
+    }
+}
+
+-(NSNumber*)memorySizeInMegabytes
+{
+    @synchronized(memorySizeInMegabytesLock)
+    {
+        if (_memorySizeInMegabytes != nil &&
+            _memorySizeInMegabytes.unsignedIntegerValue >= VMMVideoCardMemoryMinimumSize)
+        {
+            return _memorySizeInMegabytes;
+        }
+        
+        @autoreleasepool
+        {
+            int memSizeInt = -1;
+            
+            NSString* memSize = [_dictionary[VMMVideoCardMemorySizePciOrPcieKey] uppercaseString];
+            if (memSize == nil || memSize.length == 0) {
+                memSize = [_dictionary[VMMVideoCardMemorySizeBuiltInKey] uppercaseString];
+            }
+            if (memSize == nil || memSize.length == 0) {
+                memSize = [_dictionary[VMMVideoCardMemorySizeBuiltInAlternateKey] uppercaseString];
+            }
+            
+            if (memSize != nil && [memSize contains:@" MB"]) {
+                memSizeInt = [[memSize getFragmentAfter:nil andBefore:@" MB"] intValue];
+            }
+            else if (memSize != nil && [memSize contains:@" GB"]) {
+                memSizeInt = [[memSize getFragmentAfter:nil andBefore:@" GB"] intValue]*1024;
+            }
+            
+            if (memSizeInt < VMMVideoCardMemoryMinimumSize)
+            {
+                NSInteger numberOfVideoCards = [VMMVideoCardManager videoCardsWithKext].count;
+                if (numberOfVideoCards == 1 && self.kextLoaded)
+                {
+                    NSArray<NSNumber*>* apiValues = _dictionary[VMMVideoCardTemporaryKeyOpenGlApiMemorySizes];
+                    if (apiValues.count > 0 && [[apiValues firstObject] intValue] >= VMMVideoCardMemoryMinimumSize)
+                    {
+                        memSizeInt = [[apiValues firstObject] intValue];
+                    }
+                }
+                
+                //
+                // Intel video cards (and some old NVIDIAs) are integrated, and their
+                // video memory size can be calculated, or even determined by their type.
+                // Some computers reported a failure in detecting the video memory size
+                // for those video cards, so the part below is a manual fix.
+                //
+                // Reference: https://support.apple.com/en-us/HT204349
+                //
+                
+                if (memSizeInt < VMMVideoCardMemoryMinimumSize)
+                {
+                    NSString* type = self.type ? self.type : @"";
+                    NSString* deviceID = self.deviceID ? self.deviceID : @"";
+                    long long int ramMemoryGbSize = ((([VMMComputerInformation ramMemorySize]/1024)/1024)/1024);
+                    
+                    if ([type isEqualToString:VMMVideoCardTypeApple])
+                    {
+                        memSizeInt = ((int)ramMemoryGbSize)*1024;
+                    }
+                    
+                    if ([type isEqualToString:VMMVideoCardTypeIntelIris] ||
+                        [type isEqualToString:VMMVideoCardTypeIntelIrisPro] ||
+                        [type isEqualToString:VMMVideoCardTypeIntelIrisPlus])
+                    {
+                        memSizeInt = 1536;
+                    }
+                    
+                    if ([type isEqualToString:VMMVideoCardTypeIntelHD])
+                    {
+                        memSizeInt = 1536;
+                        
+                        if ([deviceID isEqualToString:VMMVideoCardDeviceIDIntelHDGraphics4000])
+                        {
+                            if (numberOfVideoCards > 1) memSizeInt = 1024;
+                            
+                            // TODO: Check the details about the afirmation below.
+                            // "Mac computers using the Intel HD Graphics 4000 as the primary
+                            //  or secondary GPU reserve 384MB–1024MB of system memory."
+                        }
+                        
+                        if ([deviceID isEqualToString:VMMVideoCardDeviceIDIntelHDGraphics3000])
+                        {
+                            if (ramMemoryGbSize == 2) memSizeInt = 256;
+                            if (ramMemoryGbSize == 4) memSizeInt = 384;
+                            if (ramMemoryGbSize == 8) memSizeInt = 512;
+                            
+                            // TODO: Exception: In the computers below, the video memory size is 384 even with 8Gb of RAM.
+                            // MacBook Pro (15-inch, Late 2011)
+                            // MacBook Pro (17-inch, Late 2011)
+                            // MacBook Pro (15-inch, Early 2011)
+                            // MacBook Pro (17-inch, Early 2011)
+                        }
+                        
+                        if ([deviceID isEqualToString:VMMVideoCardDeviceIDIntelHDGraphics])
+                        {
+                            memSizeInt = 256;
+                        }
+                    }
+                    
+                    if ([type isEqualToString:VMMVideoCardTypeNVIDIA])
+                    {
+                        if ([@[VMMVideoCardDeviceIDNVIDIAGeForce320M_1,
+                               VMMVideoCardDeviceIDNVIDIAGeForce320M_2,
+                               VMMVideoCardDeviceIDNVIDIAGeForce320M_3,
+                               VMMVideoCardDeviceIDNVIDIAGeForce320M_4,
+                               VMMVideoCardDeviceIDNVIDIAGeForce320M_5] containsObject:deviceID])
+                        {
+                            memSizeInt = 256;
+                        }
+                        
+                        if ([deviceID isEqualToString:VMMVideoCardDeviceIDNVIDIAGeForce9400M])
+                        {
+                            memSizeInt = 256;
+                            if (ramMemoryGbSize == 1) memSizeInt = 128;
+                        }
+                    }
+                }
+                
+                
+                //
+                // TODO: Fix video cards with no video memory size, or unrealistic memory size.
+                //
+                // This is common issue with Hackintoshes, but it may happen with
+                // old computers as well.
+                //
+                //
+                //  Specific case:
+                //  -> memSizeInt == 0 AND vendor == NVIDIA
+                //
+                // Apparently, this is a common bug that happens with Hackintoshes that
+                // use NVIDIA video cards that were badly configured. Considering that,
+                // there is no use in fixing that manually, since it would require a manual
+                // fix for every known NVIDIA video card that may have the issue.
+                //
+                // We can't detect the real video memory size with system_profiler.
+                // IOServiceMatching("IOPCIDevice") seems to work though.
+                //
+                // The same bug may also happen in old legitimate Apple computers, and
+                // it also seems to happen only with NVIDIA video cards.
+                //
+                // References:
+                // https://www.tonymacx86.com/threads/graphics-card-0mb.138428/
+                // https://www.tonymacx86.com/threads/gtx-770-show-vram-of-0-mb.138629/
+                // https://www.reddit.com/r/hackintosh/comments/3e5bi1/gtx_970_vram_0_mb_help/
+                // http://www.techsurvivors.net/forums/index.php?showtopic=22889
+                // https://discussions.apple.com/thread/2494867?tstart=0
+                //
+                
+                if (memSizeInt == -1)
+                {
+                    return nil;
+                }
+                if (memSizeInt < VMMVideoCardMemoryMinimumSize)
+                {
+                    return @(memSizeInt);
+                }
+            }
+            
+            _memorySizeInMegabytes = @(memSizeInt);
+            return _memorySizeInMegabytes;
+        }
+    }
+}
+
+-(BOOL)kextLoaded {
+    NSString* kextInfo = self.dictionary[VMMVideoCardKextInfoKey];
+    if (kextInfo == nil) return true;
+    
+    return ![kextInfo isEqualToString:VMMVideoCardKextInfoNotLoaded];
+}
+
+-(BOOL)isExternalGpu {
+    NSString* type = self.dictionary[VMMVideoCardDeviceTypeKey];
+    if (type == nil) return false;
+    
+    return [type isEqualToString:VMMVideoCardDeviceTypeeGPU];
+}
+
+-(BOOL)supportsMetal
+{
+    NSString* metalSupport = self.dictionary[VMMVideoCardMetalSupportKey];
+    if (metalSupport == nil) return false;
+    
+    return true;
+}
+-(VMMMetalFeatureSet)metalFeatureSet
+{
+    NSString* metalSupport = self.dictionary[VMMVideoCardMetalSupportKey];
+    if (metalSupport == nil) return VMMMetalFeatureSet_macOS_GPUFamilyNone;
+    
+    if ([metalSupport isEqualToString:@"spdisplays_supported"]) { 
+        return VMMMetalFeatureSet_macOS_GPUFamily1_v1;
+    }
+    if ([metalSupport isEqualToString:@"spdisplays_metalfeaturesetfamily12"]) {
+        return VMMMetalFeatureSet_macOS_GPUFamily1_v2;
+    }
+    if ([metalSupport isEqualToString:@"spdisplays_metalfeaturesetfamily13"]) {
+        return VMMMetalFeatureSet_macOS_GPUFamily1_v3;
+    }
+    if ([metalSupport isEqualToString:@"spdisplays_metalfeaturesetfamily14"]) {
+        return VMMMetalFeatureSet_macOS_GPUFamily1_v4;
+    }
+    if ([metalSupport isEqualToString:@"spdisplays_metalfeaturesetfamily21"]) {
+        return VMMMetalFeatureSet_macOS_GPUFamily2_v1;
+    }
+    
+    return VMMMetalFeatureSet_macOS_GPUFamilyUnknown;
+}
+
+-(NSString* _Nonnull)descriptiveName
+{
+    NSString* graphicCard = self.modelName;
+    if (graphicCard == nil)
+    {
+        NSString* type = self.type;
+        if (type == nil) type = self.vendor;
+        if (type == nil) {
+            type = (self.vendorID != nil) ? self.vendorID : nil;
+            if (type != nil) {
+                NSString* deviceID = (self.deviceID == nil) ? @"Unidentified video card" :
+                                                              [NSString stringWithFormat:@"Device with ID %@",self.deviceID];
+                return [NSString stringWithFormat:@"%@ from vendor with ID %@",deviceID,type];
+            }
+        }
+        if (type == nil) type = @"Unknown";
+        
+        NSString* deviceID = [NSString stringWithFormat:@"with device ID %@",self.deviceID];
+        if (deviceID == nil) deviceID = @"unidentified video card";
+        
+        graphicCard = [NSString stringWithFormat:@"%@ %@",type,deviceID];
+    }
+    
+    NSNumber* graphicCardSizeNumber = self.memorySizeInMegabytes;
+    if (graphicCardSizeNumber != nil)
+    {
+        NSUInteger graphicCardSize = graphicCardSizeNumber.unsignedIntegerValue;
+        graphicCard = [NSString stringWithFormat:@"%@ (%lu MB)",graphicCard,graphicCardSize];
+    }
+    
+    return graphicCard;
+}
+-(NSString* _Nonnull)veryDescriptiveName
+{
+    NSString* graphicCard = self.descriptiveName;
+    
+    if (self.isExternalGpu) {
+        graphicCard = [NSString stringWithFormat:@"%@ (eGPU)",graphicCard];
+    }
+    
+    if (!self.kextLoaded) {
+        graphicCard = [NSString stringWithFormat:@"%@ (No Kext)",graphicCard];
+    }
+    
+    return graphicCard;
+}
+
+-(BOOL)hasRealVendorID
+{
+    NSString* vendorID = self.vendorID;
+    if (vendorID == nil) return false;
+    
+    NSArray* validVendorIDs = @[VMMVideoCardVendorIDApple, VMMVideoCardVendorIDIntel,
+                                VMMVideoCardVendorIDATIAMD, VMMVideoCardVendorIDNVIDIA];
+    return [validVendorIDs containsObject:vendorID];
+}
+
+-(BOOL)hasValidMemorySize
+{
+    NSNumber* memorySize = self.memorySizeInMegabytes;
+    return memorySize != nil && memorySize.unsignedIntegerValue >= VMMVideoCardMemoryMinimumSize;
+}
+-(BOOL)isComplete
+{
+    if (self.modelName == nil) return false;
+    if (self.deviceID  == nil) return false;
+    if (self.hasValidMemorySize == false) return false;
+    return true;
+}
+-(BOOL)isVirtualMachineVideoCard
+{
+    NSString* type = self.type;
+    if (type == nil) return false;
+    
+    NSArray* vms = @[VMMVideoCardTypeVirtualBox, VMMVideoCardTypeVMware,
+                     VMMVideoCardTypeParallelsDesktop, VMMVideoCardTypeQemu];
+    return [vms containsObject:type];
+}
+
+-(BOOL)isSameVideoCard:(nonnull VMMVideoCard*)vc
+{
+    if (self.vendorID == nil) return false;
+    if (self.deviceID == nil) return false;
+    if (vc.vendorID   == nil) return false;
+    if (vc.deviceID   == nil) return false;
+    return [self.vendorID isEqualToString:vc.vendorID] && [self.deviceID isEqualToString:vc.deviceID];
+}
+-(void)mergeWithIOPCIVideoCard:(nonnull VMMVideoCard*)vc
+{
+    @autoreleasepool
+    {
+        NSMutableDictionary* newDict = [[NSMutableDictionary alloc] init];
+        for (NSString* key in _dictionary.allKeys) {
+            newDict[key] = _dictionary[key];
+        }
+        newDict[VMMVideoCardTemporaryKeyIOServiceValues] = [[NSMutableDictionary alloc] init];
+        for (NSString* key in vc.dictionary.allKeys) {
+            if (![key hasPrefix:@"IOPCIDevice_"]) {
+                if (newDict[key] == nil) newDict[key] = vc.dictionary[key];
+            }
+            else {
+                newDict[VMMVideoCardTemporaryKeyIOServiceValues][[key substringFromIndex:12]] = vc.dictionary[key];
+            }
+        }
+        
+        _dictionary = newDict;
+        _modelName = nil;
+        _chipsetName = nil;
+        _type = nil;
+        _bus = nil;
+        _deviceID = nil;
+        _vendorID = nil;
+        _vendor = nil;
+        _memorySizeInMegabytes = nil;
+    }
+}
+
+-(NSString*)description
+{
+    NSMutableArray* data = [[NSMutableArray alloc] init];
+    [data addObject:[NSString stringWithFormat:@"Model name: %@",self.modelName]];
+    [data addObject:[NSString stringWithFormat:@"Chipset name: %@",self.chipsetName]];
+    [data addObject:[NSString stringWithFormat:@"Type: %@",self.type]];
+    [data addObject:[NSString stringWithFormat:@"Bus: %@",self.bus]];
+    [data addObject:[NSString stringWithFormat:@"eGPU: %@",self.isExternalGpu ? @"true" : @"false"]];
+    [data addObject:[NSString stringWithFormat:@"Device ID: %@",self.deviceID]];
+    [data addObject:[NSString stringWithFormat:@"Vendor ID: %@",self.vendorID]];
+    [data addObject:[NSString stringWithFormat:@"Vendor: %@",self.vendor]];
+    [data addObject:[NSString stringWithFormat:@"Memory size: %@",self.memorySizeInMegabytes]];
+    [data addObject:[NSString stringWithFormat:@"Kext Loaded: %@",self.kextLoaded ? @"true" : @"false"]];
+    [data addObject:[NSString stringWithFormat:@"Data: %@",self.dictionary]];
+    NSString* string = [data componentsJoinedByString:@", "];
+    return [NSString stringWithFormat:@"{%@}",string];
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMVideoCardManager.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMVideoCardManager.h
@@ -1,0 +1,35 @@
+//
+//  VMMVideoCardManager.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 04/10/18.
+//  Copyright © 2018 VitorMM. All rights reserved.
+//
+
+#ifndef VMMVideoCardManager_Class
+#define VMMVideoCardManager_Class
+
+#import <Foundation/Foundation.h>
+#import "VMMVideoCard.h"
+
+@interface VMMVideoCardManager : NSObject
+
+/*!
+ * @discussion  Returns every available information about every available video card.
+ * @return      A VMMVideoCard array with information related with every available video card.
+ */
++(NSArray<VMMVideoCard*>* _Nonnull)videoCards;
+
++(NSArray<VMMVideoCard*>* _Nonnull)videoCardsWithKext;
+
+/*!
+ * @discussion  Returns every available information about the main video card.
+ * @return      A VMMVideoCard with information related with the main video card.
+ */
++(VMMVideoCard* _Nullable)bestVideoCard;
++(VMMVideoCard* _Nullable)bestInternalVideoCard;
++(VMMVideoCard* _Nullable)bestExternalVideoCard;
+
+@end
+
+#endif

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMVideoCardManager.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMVideoCardManager.m
@@ -1,0 +1,350 @@
+//
+//  VMMVideoCardManager.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 04/10/18.
+//  Copyright © 2018 VitorMM. All rights reserved.
+//
+
+#import "VMMVideoCardManager.h"
+
+#import "NSMutableArray+Extension.h"
+#import "NSArray+Extension.h"
+#import "NSString+Extension.h"
+#import "VMMLogUtility.h"
+
+@implementation VMMVideoCardManager
+
++(NSMutableArray<VMMVideoCard*>* _Nonnull)systemProfilerVideoCards
+{
+    NSArray* displayOutput = [VMMComputerInformation systemProfilerItemsForDataType:SPDisplaysDataType];
+    if (displayOutput == nil) {
+        return [[NSMutableArray alloc] init];
+    }
+    
+    return [[displayOutput filter:^BOOL(NSDictionary*  _Nonnull object) { return object.count > 0; }]
+                              map:^id _Nullable(NSDictionary*  _Nonnull object) {
+        return [[VMMVideoCard alloc] initVideoCardWithDictionary:object];
+    }];
+}
+
++(id)getValuesFromRegistryEntryObject:(id)keyData
+{
+    if (keyData == nil) {
+        return nil;
+    }
+
+    if ([keyData isKindOfClass:[NSData class]])
+    {
+        NSString* keyDataString;
+        NSString* keyDataAsciiString = [[NSString alloc] initWithData:keyData encoding:NSASCIIStringEncoding];
+        if (!keyDataAsciiString)
+        {
+            keyDataString = [[NSString alloc] initWithData:keyData encoding:NSUTF8StringEncoding];
+        }
+        else
+        {
+            NSString* keyDataUtf8String = [[NSString alloc] initWithData:keyData encoding:NSUTF8StringEncoding];
+            if (keyDataUtf8String != nil && [keyDataUtf8String length] < [keyDataAsciiString length]) {
+                keyDataString = keyDataUtf8String;
+            }
+            else {
+                keyDataString = keyDataAsciiString;
+            }
+        }
+        
+        return @[keyDataString,keyData];
+    }
+    
+    if ([keyData isKindOfClass:[NSDictionary class]])
+    {
+        NSMutableDictionary* dict = [[NSMutableDictionary alloc] init];
+        for (NSString* key in ((NSDictionary*)keyData).allKeys)
+        {
+            NSObject* newVal = [self getValuesFromRegistryEntryObject:[((NSDictionary*)keyData) objectForKey:key]];
+            if (newVal != nil) dict[key] = newVal;
+        }
+        return dict;
+    }
+    
+    if ([keyData isKindOfClass:[NSArray class]])
+    {
+        NSMutableArray* array = [[NSMutableArray alloc] init];
+        for (NSString* val in ((NSArray*)keyData))
+        {
+            NSObject* newVal = [self getValuesFromRegistryEntryObject:val];
+            if (newVal != nil) [array addObject:newVal];
+        }
+        return array;
+    }
+    
+    return keyData;
+}
++(NSMutableArray<VMMVideoCard*>* _Nonnull)videoCardsFromIOServiceMatch
+{
+    NSMutableArray* graphicCardDicts = [[NSMutableArray alloc] init];
+    
+    CFMutableDictionaryRef matchDict = IOServiceMatching("IOPCIDevice");
+    
+    io_iterator_t iterator;
+    if (IOServiceGetMatchingServices(kIOMasterPortDefault,matchDict,&iterator) == kIOReturnSuccess)
+    {
+        io_registry_entry_t regEntry;
+        while ((regEntry = IOIteratorNext(iterator)))
+        {
+            CFStringRef gpuName;
+            @try {
+                gpuName = IORegistryEntrySearchCFProperty(regEntry, kIOServicePlane, CFSTR("IOName"),
+                                                                      kCFAllocatorDefault, kNilOptions);
+                if (gpuName && CFStringCompare(gpuName, CFSTR("display"), 0) == kCFCompareEqualTo)
+                {
+                    NSMutableDictionary* graphicCardDict = [[NSMutableDictionary alloc] init];
+                    
+                    CFMutableDictionaryRef serviceDictionary;
+                    if (IORegistryEntryCreateCFProperties(regEntry, &serviceDictionary, kCFAllocatorDefault, kNilOptions) != kIOReturnSuccess)
+                    {
+                        IOObjectRelease(regEntry);
+                        CFRelease(gpuName);
+                        continue;
+                    }
+                    NSMutableDictionary* service = (__bridge NSMutableDictionary*)serviceDictionary;
+                    
+                    NSData* gpuModel = service[@"model"];
+                    if (gpuModel != nil && [gpuModel isKindOfClass:[NSData class]])
+                    {
+                        NSString *gpuModelString = [[NSString alloc] initWithData:gpuModel encoding:NSASCIIStringEncoding];
+                        if (gpuModelString != nil)
+                        {
+                            gpuModelString = [gpuModelString stringByReplacingOccurrencesOfString:@"\0" withString:@" "];
+                            gpuModelString = [gpuModelString stringByReplacingOccurrencesOfString:@"  " withString:@" "];
+                            graphicCardDict[VMMVideoCardModelNameKey] = gpuModelString;
+                        }
+                    }
+                    
+                    NSData* deviceID = service[@"device-id"];
+                    if (deviceID != nil && [deviceID isKindOfClass:[NSData class]])
+                    {
+                        NSString* hexDeviceIDString = [NSString stringWithFormat:@"%@",deviceID];
+                        if (hexDeviceIDString.length > 5)
+                        {
+                            NSString* firstPart  = [hexDeviceIDString substringWithRange:NSMakeRange(3, 2)];
+                            NSString* secondPart = [hexDeviceIDString substringWithRange:NSMakeRange(1, 2)];
+                            hexDeviceIDString = [NSString stringWithFormat:@"0x%@%@",firstPart,secondPart];
+                            hexDeviceIDString = hexDeviceIDString.lowercaseString;
+                            
+                            if ([hexDeviceIDString matchesWithRegex:@"0x[0-9a-f]{4}"])
+                            {
+                                graphicCardDict[VMMVideoCardDeviceIDKey] = hexDeviceIDString;
+                            }
+                        }
+                    }
+                    
+                    NSData* vendorID = service[@"vendor-id"];
+                    if (vendorID != nil && [vendorID isKindOfClass:[NSData class]])
+                    {
+                        NSString* vendorIDString = [NSString stringWithFormat:@"%@",vendorID];
+                        if (vendorIDString.length > 5)
+                        {
+                            NSString* firstPart  = [vendorIDString substringWithRange:NSMakeRange(3, 2)];
+                            NSString* secondPart = [vendorIDString substringWithRange:NSMakeRange(1, 2)];
+                            vendorIDString = [NSString stringWithFormat:@"0x%@%@",firstPart,secondPart];
+                            vendorIDString = vendorIDString.lowercaseString;
+                            
+                            if ([vendorIDString matchesWithRegex:@"0x[0-9a-f]{4}"])
+                            {
+                                graphicCardDict[VMMVideoCardVendorIDKey] = vendorIDString;
+                            }
+                        }
+                    }
+                    
+                    graphicCardDict[VMMVideoCardBusKey] = VMMVideoCardBusPCI;
+                    NSData* hdaGfx = service[@"hda-gfx"];
+                    if (hdaGfx != nil && [hdaGfx isKindOfClass:[NSData class]])
+                    {
+                        NSString* hdaGfxString = [[NSString alloc] initWithData:hdaGfx encoding:NSASCIIStringEncoding];
+                        if (hdaGfxString != nil && [hdaGfxString isEqualToString:@"onboard-1"])
+                        {
+                            graphicCardDict[VMMVideoCardBusKey] = VMMVideoCardBusBuiltIn;
+                        }
+                    }
+                    
+                    _Bool vramValueInBytes = TRUE;
+                    CFTypeRef vramSize = IORegistryEntrySearchCFProperty(regEntry, kIOServicePlane, CFSTR("VRAM,totalsize"),
+                                                                         kCFAllocatorDefault, kIORegistryIterateRecursively);
+                    if (!vramSize)
+                    {
+                        vramValueInBytes = FALSE;
+                        vramSize = IORegistryEntrySearchCFProperty(regEntry, kIOServicePlane, CFSTR("VRAM,totalMB"),
+                                                                   kCFAllocatorDefault, kIORegistryIterateRecursively);
+                    }
+                    
+                    if (vramSize != NULL)
+                    {
+                        mach_vm_size_t size = 0;
+                        CFTypeID type = CFGetTypeID(vramSize);
+                        if (type == CFDataGetTypeID())
+                        {
+                            if (CFDataGetLength(vramSize) == sizeof(uint32_t))
+                            {
+                                size = (mach_vm_size_t)*(const uint32_t*)CFDataGetBytePtr(vramSize);
+                            }
+                            else
+                            {
+                                size = *(const uint64_t*)CFDataGetBytePtr(vramSize);
+                            }
+                        }
+                        else
+                        {
+                            if (type == CFNumberGetTypeID())
+                            {
+                                CFNumberGetValue(vramSize, kCFNumberSInt64Type, &size);
+                            }
+                        }
+                        
+                        if (vramValueInBytes) size >>= 20;
+                        
+                        graphicCardDict[VMMVideoCardMemorySizeBuiltInKey] = [NSString stringWithFormat:@"%llu MB", size];
+                        
+                        CFRelease(vramSize);
+                    }
+                    
+                    // Reference:
+                    // https://gist.github.com/JonnyJD/6126680
+                    
+                    CFMutableDictionaryRef properties;
+                    CFIndex count;
+                    CFTypeRef *keys;
+                    CFTypeRef *values;
+                    int i;
+                    
+                    IORegistryEntryCreateCFProperties(regEntry, &properties, kCFAllocatorDefault, kNilOptions);
+                    count = CFDictionaryGetCount(properties);
+                    keys = (CFTypeRef *) malloc(sizeof(CFTypeRef) * count);
+                    values = (CFTypeRef *) malloc(sizeof(CFTypeRef) * count);
+                    CFDictionaryGetKeysAndValues(properties, (const void **) keys, (const void **) values);
+                    free(values);
+                    for (i = 0; i < count; i++)
+                    {
+                        CFTypeRef cf_type = keys[i];
+                        NSString* key = [NSString stringWithCFType:cf_type];
+                        if (key == nil) key = [NSString stringWithCFTypeIDDescription:cf_type];
+                        
+                        id keyVal = service[key];
+                        keyVal = [self getValuesFromRegistryEntryObject:keyVal];
+                        graphicCardDict[[@"IOPCIDevice_" stringByAppendingString:key]] = keyVal;
+                    }
+                    free(keys);
+                    
+                    CFRelease(serviceDictionary);
+                    [graphicCardDicts addObject:graphicCardDict];
+                }
+            }
+            @catch (NSException* exc) {
+                NSDebugLog(@"%@: %@", exc.name, exc.reason);
+            }
+            @finally {
+                if (gpuName != NULL) CFRelease(gpuName);
+                IOObjectRelease(regEntry);
+            }
+        }
+        
+        IOObjectRelease(iterator);
+    }
+    
+    return [[[graphicCardDicts filter:^BOOL(NSDictionary* _Nonnull object) {
+        return object.count > 0;
+        
+    }] map:^VMMVideoCard* _Nonnull(NSDictionary* _Nonnull object) {
+        return [[VMMVideoCard alloc] initVideoCardWithDictionary:object];
+        
+    }] filter:^BOOL(VMMVideoCard* _Nonnull vc) {
+        // This video card should be ignored:
+        // Intel Corporation Mobile 945GM/GMS/GME, 943/940GML Express Integrated Graphics Controller
+        // https://steamcommunity.com/app/259680/discussions/1/405692224243163860/
+        // https://www.overclockers.com/forums/showthread.php/656895-can-this-intel-core-2-duo-processor-be-oc
+        // https://ubuntuforums.org/archive/index.php/t-1287852.html
+        // https://lists.opensuse.org/opensuse/2009-06/msg00099.html
+         
+        return !([vc.vendorID isEqualToString:VMMVideoCardVendorIDIntel] && [vc.deviceID isEqualToString:@"0x27a6"]);
+    }];
+}
+
+
+
++(NSArray<VMMVideoCard*>* _Nonnull)videoCards
+{
+    static NSMutableArray<VMMVideoCard*>* videoCards = nil;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        @autoreleasepool
+        {
+            videoCards = [self systemProfilerVideoCards];
+            NSMutableArray<VMMVideoCard*>* extraVideoCards = [[NSMutableArray alloc] init];
+            
+            NSArray<VMMVideoCard*>* ioVideoCards = [self videoCardsFromIOServiceMatch];
+            for (VMMVideoCard* iovc in ioVideoCards) {
+                BOOL found = false;
+                for (VMMVideoCard* spvc in videoCards) {
+                    if ([spvc isSameVideoCard:iovc]) {
+                        found = true;
+                        [spvc mergeWithIOPCIVideoCard:iovc];
+                    }
+                }
+                if (!found) [extraVideoCards addObject:iovc];
+            }
+            [videoCards addObjectsFromArray:extraVideoCards];
+            
+            [videoCards sortUsingDescriptors:@[[[NSSortDescriptor alloc] initWithKey:@"memorySizeInMegabytes" ascending:NO]]];
+            
+            [videoCards sortBySelector:@selector(vendorID)
+                               inOrder:@[VMMVideoCardVendorIDATIAMD, VMMVideoCardVendorIDNVIDIA, VMMVideoCardVendorIDIntel]];
+            [videoCards sortBySelector:@selector(bus)
+                               inOrder:@[VMMVideoCardBusPCIe, VMMVideoCardBusPCI, VMMVideoCardBusBuiltIn]];
+            
+            [videoCards sortUsingDescriptors:@[[[NSSortDescriptor alloc] initWithKey:@"isComplete"    ascending:NO]]];
+            [videoCards sortUsingDescriptors:@[[[NSSortDescriptor alloc] initWithKey:@"isExternalGpu" ascending:NO]]];
+        }
+    });
+    
+    return videoCards;
+}
++(NSArray<VMMVideoCard*>* _Nonnull)videoCardsWithKext
+{
+    return [[[self videoCards] mutableCopy] filter:^BOOL(VMMVideoCard * _Nonnull object) { return object.kextLoaded; }];
+}
+
+
++(VMMVideoCard* _Nullable)bestVideoCard
+{
+    NSMutableArray* videoCards = [[self videoCardsWithKext] mutableCopy];
+    if (videoCards.count == 0) videoCards = [[self videoCards] mutableCopy];
+    if (videoCards.count == 0) return nil;
+    
+    [videoCards sortUsingDescriptors:@[[[NSSortDescriptor alloc] initWithKey:@"isComplete" ascending:NO]]];
+    return videoCards.firstObject;
+}
++(VMMVideoCard* _Nullable)bestInternalVideoCard
+{
+    NSMutableArray* videoCards = [[self videoCardsWithKext] mutableCopy];
+    if (videoCards.count == 0) videoCards = [[self videoCards] mutableCopy];
+    if (videoCards.count == 0) return nil;
+    
+    [videoCards sortUsingDescriptors:@[[[NSSortDescriptor alloc] initWithKey:@"isComplete" ascending:NO]]];
+    videoCards = [videoCards filter:^BOOL(VMMVideoCard * _Nonnull object) { return !object.isExternalGpu; }];
+    
+    if (videoCards.count == 0) return nil;
+    return videoCards.firstObject;
+}
++(VMMVideoCard* _Nullable)bestExternalVideoCard
+{
+    NSMutableArray* videoCards = [[self videoCardsWithKext] mutableCopy];
+    if (videoCards == nil || videoCards.count == 0) return nil;
+    
+    videoCards = [videoCards filter:^BOOL(VMMVideoCard * _Nonnull object) { return object.isComplete && object.isExternalGpu; }];
+    
+    if (videoCards.count == 0) return nil;
+    return videoCards.firstObject;
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMView.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMView.h
@@ -1,0 +1,28 @@
+//
+//  VMMView.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 07/11/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface VMMView : NSView
+
+typedef NS_ENUM(NSUInteger, VMMViewBorderSide)
+{
+    VMMViewBorderSideLeft   = 1,
+    VMMViewBorderSideRight  = 2,
+    VMMViewBorderSideTop    = 4,
+    VMMViewBorderSideBottom = 8
+};
+
+@property (nonatomic, strong) NSColor* borderColor;
+@property (nonatomic, strong) NSNumber* borderThickness;
+@property (nonatomic, strong) NSNumber* borderSides;
+
+@property (nonatomic, strong) NSColor* backgroundColor;
+@property (nonatomic, strong) NSImage* backgroundImage;
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMView.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMView.m
@@ -1,0 +1,64 @@
+//
+//  VMMView.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 07/11/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import "VMMView.h"
+
+@implementation VMMView
+
+-(void)setBackgroundColor:(NSColor*)color
+{
+    _backgroundColor = color;
+    [self setNeedsDisplay:YES];
+}
+-(void)setBackgroundImage:(NSImage *)backgroundImage
+{
+    _backgroundImage = backgroundImage;
+    [self setNeedsDisplay:YES];
+}
+
+-(void)drawRect:(NSRect)dirtyRect
+{
+    CGFloat borderThickness = 0;
+    if (_borderColor)
+    {
+        borderThickness = _borderThickness.doubleValue;
+        
+        [_borderColor setFill];
+        NSRectFillUsingOperation(dirtyRect, NSCompositeSourceOver);
+    }
+    
+    if (_backgroundColor)
+    {
+        [_backgroundColor setFill];
+        
+        BOOL hasLeftMargin   = (_borderSides == nil || (_borderSides.unsignedIntegerValue & VMMViewBorderSideLeft)   != 0);
+        BOOL hasRightMargin  = (_borderSides == nil || (_borderSides.unsignedIntegerValue & VMMViewBorderSideRight)  != 0);
+        BOOL hasTopMargin    = (_borderSides == nil || (_borderSides.unsignedIntegerValue & VMMViewBorderSideTop)    != 0);
+        BOOL hasBottomMargin = (_borderSides == nil || (_borderSides.unsignedIntegerValue & VMMViewBorderSideBottom) != 0);
+        
+        CGFloat leftMargin   = hasLeftMargin   ? borderThickness : 0;
+        CGFloat rightMargin  = hasRightMargin  ? borderThickness : 0;
+        CGFloat topMargin    = hasTopMargin    ? borderThickness : 0;
+        CGFloat bottomMargin = hasBottomMargin ? borderThickness : 0;
+        
+        NSRect bgRect = NSMakeRect(dirtyRect.origin.x + leftMargin, dirtyRect.origin.y + bottomMargin,
+                                   dirtyRect.size.width - (leftMargin + rightMargin),
+                                   dirtyRect.size.height - (topMargin + bottomMargin));
+        NSRectFillUsingOperation(bgRect, NSCompositeSourceOver);
+    }
+    
+    [super drawRect:dirtyRect];
+    
+    if (_backgroundImage)
+    {
+        [_backgroundImage setSize:self.frame.size];
+        [_backgroundImage drawAtPoint:NSZeroPoint fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1];
+    }
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMVirtualKeycode.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMVirtualKeycode.h
@@ -1,0 +1,186 @@
+/*
+ *  Summary:
+ *    Virtual keycodes
+ *
+ *  Discussion:
+ *    These constants are the virtual keycodes defined originally in
+ *    Inside Mac Volume V, pg. V-191. They identify physical keys on a
+ *    keyboard. Those constants with "ANSI" in the name are labeled
+ *    according to the key position on an ANSI-standard US keyboard.
+ *    For example, kVK_ANSI_A indicates the virtual keycode for the key
+ *    with the letter 'A' in the US keyboard layout. Other keyboard
+ *    layouts may have the 'A' key label on a different physical key;
+ *    in this case, pressing 'A' will generate a different virtual
+ *    keycode.
+ */
+// http://stackoverflow.com/a/16125341/4370893
+//
+// Power Mac Keypad Enter / iBook Enter Key (0x34):
+// https://bugs.chromium.org/p/chromium/issues/detail?id=542634
+// https://www.virtualbox.org/svn/vbox/trunk/src/VBox/Frontends/VirtualBox/src/platform/darwin/DarwinKeyboard.cpp
+//
+// Many keys that weren't in the first references:
+// http://www.insanelymac.com/forum/topic/236835-updated-2012-genericbrightnesskext/page-16
+//
+// Context Menu Key (0x6E):
+// https://chromium.googlesource.com/chromium/src/+/lkgr/ui/events/keycodes/keyboard_code_conversion_mac.mm
+//
+// Spotlight (0x81), Dashboard (0x82), Launchpad (0x83):
+// https://github.com/RehabMan/OS-X-Voodoo-PS2-Controller/blob/master/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+//
+// Tilde (0x0A):
+// https://github.com/SFML/SFML/blob/master/src/SFML/Window/OSX/HIDInputManager.mm
+
+#import <Cocoa/Cocoa.h>
+
+@interface VMMVirtualKeycode : NSObject
+
++(nonnull NSArray<NSString*>*)allKeyNames;
+
++(nonnull NSDictionary*)virtualKeycodeNames;
++(nullable NSString*)nameOfVirtualKeycode:(CGKeyCode)key;
+
+@end
+
+enum {
+    kVK_ANSI_A                    = 0x00,
+    kVK_ANSI_S                    = 0x01,
+    kVK_ANSI_D                    = 0x02,
+    kVK_ANSI_F                    = 0x03,
+    kVK_ANSI_H                    = 0x04,
+    kVK_ANSI_G                    = 0x05,
+    kVK_ANSI_Z                    = 0x06,
+    kVK_ANSI_X                    = 0x07,
+    kVK_ANSI_C                    = 0x08,
+    kVK_ANSI_V                    = 0x09,
+    kVK_ISO_Section               = 0x0A, // Not present in keycode usage? Possibly Tilde; have to test
+    kVK_ANSI_B                    = 0x0B,
+    kVK_ANSI_Q                    = 0x0C,
+    kVK_ANSI_W                    = 0x0D,
+    kVK_ANSI_E                    = 0x0E,
+    kVK_ANSI_R                    = 0x0F,
+    kVK_ANSI_Y                    = 0x10,
+    kVK_ANSI_T                    = 0x11,
+    kVK_ANSI_1                    = 0x12,
+    kVK_ANSI_2                    = 0x13,
+    kVK_ANSI_3                    = 0x14,
+    kVK_ANSI_4                    = 0x15,
+    kVK_ANSI_6                    = 0x16,
+    kVK_ANSI_5                    = 0x17,
+    kVK_ANSI_Equal                = 0x18,
+    kVK_ANSI_9                    = 0x19,
+    kVK_ANSI_7                    = 0x1A,
+    kVK_ANSI_Minus                = 0x1B,
+    kVK_ANSI_8                    = 0x1C,
+    kVK_ANSI_0                    = 0x1D,
+    kVK_ANSI_RightBracket         = 0x1E,
+    kVK_ANSI_O                    = 0x1F,
+    kVK_ANSI_U                    = 0x20,
+    kVK_ANSI_LeftBracket          = 0x21,
+    kVK_ANSI_I                    = 0x22,
+    kVK_ANSI_P                    = 0x23,
+    kVK_Enter                     = 0x24, /* Mac calls it Return */
+    kVK_ANSI_L                    = 0x25,
+    kVK_ANSI_J                    = 0x26,
+    kVK_ANSI_Quote                = 0x27,
+    kVK_ANSI_K                    = 0x28,
+    kVK_ANSI_Semicolon            = 0x29,
+    kVK_ANSI_Backslash            = 0x2A,
+    kVK_ANSI_Comma                = 0x2B,
+    kVK_ANSI_Slash                = 0x2C,
+    kVK_ANSI_N                    = 0x2D,
+    kVK_ANSI_M                    = 0x2E,
+    kVK_ANSI_Period               = 0x2F,
+    kVK_Tab                       = 0x30,
+    kVK_Space                     = 0x31,
+    kVK_ANSI_Grave                = 0x32,
+    kVK_Delete                    = 0x33, /* Backspace in Windows keyboards */
+    kVK_Play                      = 0x34, // Not present in keycode usage?
+    kVK_Escape                    = 0x35,
+    kVK_RightCommand              = 0x36,
+    kVK_LeftCommand               = 0x37,
+    kVK_LeftShift                 = 0x38,
+    kVK_CapsLock                  = 0x39,
+    kVK_LeftOption                = 0x3A,
+    kVK_LeftControl               = 0x3B,
+    kVK_RightShift                = 0x3C,
+    kVK_RightOption               = 0x3D,
+    kVK_RightControl              = 0x3E,
+    kVK_Function                  = 0x3F, // Not present in keycode usage?
+    kVK_F17                       = 0x40,
+    kVK_ANSI_KeypadDecimal        = 0x41,
+    kVK_Next                      = 0x42, // Not present in keycode usage?
+    kVK_ANSI_KeypadMultiply       = 0x43,
+    // 44?
+    kVK_ANSI_KeypadPlus           = 0x45,
+    // 46?
+    kVK_ANSI_KeypadClear          = 0x47, /* This is also Num Lock */
+    kVK_VolumeUp                  = 0x48,
+    kVK_VolumeDown                = 0x49,
+    kVK_Mute                      = 0x4A,
+    kVK_ANSI_KeypadDivide         = 0x4B,
+    kVK_ANSI_KeypadEnter          = 0x4C,
+    kVK_Previous                  = 0x4D, // Not present in keycode usage?
+    kVK_ANSI_KeypadMinus          = 0x4E,
+    kVK_F18                       = 0x4F,
+    kVK_F19                       = 0x50,
+    kVK_ANSI_KeypadEquals         = 0x51,
+    kVK_ANSI_Keypad0              = 0x52,
+    kVK_ANSI_Keypad1              = 0x53,
+    kVK_ANSI_Keypad2              = 0x54,
+    kVK_ANSI_Keypad3              = 0x55,
+    kVK_ANSI_Keypad4              = 0x56,
+    kVK_ANSI_Keypad5              = 0x57,
+    kVK_ANSI_Keypad6              = 0x58,
+    kVK_ANSI_Keypad7              = 0x59,
+    kVK_F20                       = 0x5A,
+    kVK_ANSI_Keypad8              = 0x5B,
+    kVK_ANSI_Keypad9              = 0x5C,
+    kVK_JIS_Yen                   = 0x5D,
+    kVK_JIS_Underscore            = 0x5E, // Not present in keycode usage?
+    kVK_JIS_KeypadComma           = 0x5F,
+    kVK_F5                        = 0x60,
+    kVK_F6                        = 0x61,
+    kVK_F7                        = 0x62,
+    kVK_F3                        = 0x63,
+    kVK_F8                        = 0x64,
+    kVK_F9                        = 0x65,
+    kVK_JIS_Eisu                  = 0x66, // Not present in keycode usage?
+    kVK_F11                       = 0x67,
+    kVK_JIS_Kana                  = 0x68, // Not present in keycode usage?
+    kVK_F13                       = 0x69,
+    kVK_F16                       = 0x6A,
+    kVK_F14                       = 0x6B,
+    // 6C?
+    kVK_F10                       = 0x6D,
+    kVK_ContextMenu               = 0x6E, /* That strange key next to Alt Gr in Windows keyboards */
+    kVK_F12                       = 0x6F,
+    kVK_VidMirror                 = 0x70, // Not present in keycode usage? /* Toggle between extended desktop and clone mode */
+    kVK_F15                       = 0x71,
+    kVK_Help                      = 0x72, // Maybe Insert in different keyboard? Have to check
+    kVK_Home                      = 0x73,
+    kVK_PageUp                    = 0x74,
+    kVK_ForwardDelete             = 0x75,
+    kVK_F4                        = 0x76,
+    kVK_End                       = 0x77,
+    kVK_F2                        = 0x78,
+    kVK_PageDown                  = 0x79,
+    kVK_F1                        = 0x7A,
+    kVK_LeftArrow                 = 0x7B,
+    kVK_RightArrow                = 0x7C,
+    kVK_DownArrow                 = 0x7D,
+    kVK_UpArrow                   = 0x7E,
+    kVK_Power                     = 0x7F, // Maybe Menu in different keyboard? Wtf is menu? Have to check
+    // 80?
+    kVK_Spotlight                 = 0x81, // Not present in keycode usage?
+    kVK_Dashboard                 = 0x82, // Not present in keycode usage?
+    kVK_Launchpad                 = 0x83, // Not present in keycode usage?
+    // 84 ~ 8F?
+    kVK_BrightnessUp              = 0x90, // Not present in keycode usage?
+    kVK_BrightnessDown            = 0x91, // Not present in keycode usage?
+    kVK_Eject                     = 0x92, // Not present in keycode usage?
+    // 93 ~ 9F?
+    kVK_ExposesAll                = 0xA0, // Not present in keycode usage?
+    kVK_ExposesDesktop            = 0xA1  // Not present in keycode usage?
+    // A2 ~ FF?
+};

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMVirtualKeycode.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMVirtualKeycode.m
@@ -1,0 +1,176 @@
+//
+//  VMMVirtualKeycode.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 09/08/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import "VMMVirtualKeycode.h"
+#import "VMMLocalizationUtility.h"
+
+@implementation VMMVirtualKeycode
+
+NSDictionary* _virtualKeycodeNames;
+
++(nonnull NSArray<NSString*>*)allKeyNames
+{
+    return self.virtualKeycodeNames.allValues;
+}
+
++(nonnull NSDictionary*)virtualKeycodeNames
+{
+    if (!_virtualKeycodeNames)
+    {
+        _virtualKeycodeNames = @{
+                                @(kVK_ANSI_A)             : @"A",
+                                @(kVK_ANSI_S)             : @"S",
+                                @(kVK_ANSI_D)             : @"D",
+                                @(kVK_ANSI_F)             : @"F",
+                                @(kVK_ANSI_H)             : @"H",
+                                @(kVK_ANSI_G)             : @"G",
+                                @(kVK_ANSI_Z)             : @"Z",
+                                @(kVK_ANSI_X)             : @"X",
+                                @(kVK_ANSI_C)             : @"C",
+                                @(kVK_ANSI_V)             : @"V",
+                                @(kVK_ISO_Section)        : @"ISO Section",
+                                @(kVK_ANSI_B)             : @"B",
+                                @(kVK_ANSI_Q)             : @"Q",
+                                @(kVK_ANSI_W)             : @"W",
+                                @(kVK_ANSI_E)             : @"E",
+                                @(kVK_ANSI_R)             : @"R",
+                                @(kVK_ANSI_Y)             : @"Y",
+                                @(kVK_ANSI_T)             : @"T",
+                                @(kVK_ANSI_1)             : @"1",
+                                @(kVK_ANSI_2)             : @"2",
+                                @(kVK_ANSI_3)             : @"3",
+                                @(kVK_ANSI_4)             : @"4",
+                                @(kVK_ANSI_6)             : @"6",
+                                @(kVK_ANSI_5)             : @"5",
+                                @(kVK_ANSI_Equal)         : VMMLocalizedString(@"Equal"),
+                                @(kVK_ANSI_9)             : @"9",
+                                @(kVK_ANSI_7)             : @"7",
+                                @(kVK_ANSI_Minus)         : VMMLocalizedString(@"Minus"),
+                                @(kVK_ANSI_8)             : @"8",
+                                @(kVK_ANSI_0)             : @"0",
+                                @(kVK_ANSI_RightBracket)  : VMMLocalizedString(@"Right Bracket"),
+                                @(kVK_ANSI_O)             : @"O",
+                                @(kVK_ANSI_U)             : @"U",
+                                @(kVK_ANSI_LeftBracket)   : VMMLocalizedString(@"Left Bracket"),
+                                @(kVK_ANSI_I)             : @"I",
+                                @(kVK_ANSI_P)             : @"P",
+                                @(kVK_Enter)              : VMMLocalizedString(@"Return"),
+                                @(kVK_ANSI_L)             : @"L",
+                                @(kVK_ANSI_J)             : @"J",
+                                @(kVK_ANSI_Quote)         : VMMLocalizedString(@"Quote"),
+                                @(kVK_ANSI_K)             : @"K",
+                                @(kVK_ANSI_Semicolon)     : VMMLocalizedString(@"Semicolon"),
+                                @(kVK_ANSI_Backslash)     : VMMLocalizedString(@"Backslash"),
+                                @(kVK_ANSI_Comma)         : VMMLocalizedString(@"Comma"),
+                                @(kVK_ANSI_Slash)         : VMMLocalizedString(@"Slash"),
+                                @(kVK_ANSI_N)             : @"N",
+                                @(kVK_ANSI_M)             : @"M",
+                                @(kVK_ANSI_Period)        : VMMLocalizedString(@"Period"),
+                                @(kVK_Tab)                : VMMLocalizedString(@"Tab"),
+                                @(kVK_Space)              : VMMLocalizedString(@"Space"),
+                                @(kVK_ANSI_Grave)         : VMMLocalizedString(@"Grave"),
+                                @(kVK_Delete)             : VMMLocalizedString(@"Delete"),
+                                @(kVK_Play)               : VMMLocalizedString(@"Play"),
+                                @(kVK_Escape)             : VMMLocalizedString(@"Escape"),
+                                @(kVK_RightCommand)       : VMMLocalizedString(@"Right Command"),
+                                @(kVK_LeftCommand)        : VMMLocalizedString(@"Left Command"),
+                                @(kVK_LeftShift)          : VMMLocalizedString(@"Left Shift"),
+                                @(kVK_CapsLock)           : VMMLocalizedString(@"Caps Lock"),
+                                @(kVK_LeftOption)         : VMMLocalizedString(@"Left Option"),
+                                @(kVK_LeftControl)        : VMMLocalizedString(@"Left Control"),
+                                @(kVK_RightShift)         : VMMLocalizedString(@"Right Shift"),
+                                @(kVK_RightOption)        : VMMLocalizedString(@"Right Option"),
+                                @(kVK_RightControl)       : VMMLocalizedString(@"Right Control"),
+                                @(kVK_Function)           : VMMLocalizedString(@"Function"),
+                                @(kVK_F17)                : @"F17",
+                                @(kVK_ANSI_KeypadDecimal) : VMMLocalizedString(@"Keypad Decimal"),
+                                @(kVK_Next)               : VMMLocalizedString(@"Next"),
+                                @(kVK_ANSI_KeypadMultiply): VMMLocalizedString(@"Keypad Multiply"),
+                                // @(0x44)                   : @"",
+                                @(kVK_ANSI_KeypadPlus)    : VMMLocalizedString(@"Keypad Plus"),
+                                // @(0x46)                   : @"",
+                                @(kVK_ANSI_KeypadClear)   : VMMLocalizedString(@"Keypad Clear"),
+                                @(kVK_VolumeUp)           : VMMLocalizedString(@"Volume Up"),
+                                @(kVK_VolumeDown)         : VMMLocalizedString(@"Volume Down"),
+                                @(kVK_Mute)               : VMMLocalizedString(@"Mute"),
+                                @(kVK_ANSI_KeypadDivide)  : VMMLocalizedString(@"Keypad Divide"),
+                                @(kVK_ANSI_KeypadEnter)   : VMMLocalizedString(@"Keypad Enter"),
+                                @(kVK_Previous)           : VMMLocalizedString(@"Previous"),
+                                @(kVK_ANSI_KeypadMinus)   : VMMLocalizedString(@"Keypad Minus"),
+                                @(kVK_F18)                : @"F18",
+                                @(kVK_F19)                : @"F19",
+                                @(kVK_ANSI_KeypadEquals)  : VMMLocalizedString(@"Keypad Equals"),
+                                @(kVK_ANSI_Keypad0)       : VMMLocalizedString(@"Keypad 0"),
+                                @(kVK_ANSI_Keypad1)       : VMMLocalizedString(@"Keypad 1"),
+                                @(kVK_ANSI_Keypad2)       : VMMLocalizedString(@"Keypad 2"),
+                                @(kVK_ANSI_Keypad3)       : VMMLocalizedString(@"Keypad 3"),
+                                @(kVK_ANSI_Keypad4)       : VMMLocalizedString(@"Keypad 4"),
+                                @(kVK_ANSI_Keypad5)       : VMMLocalizedString(@"Keypad 5"),
+                                @(kVK_ANSI_Keypad6)       : VMMLocalizedString(@"Keypad 6"),
+                                @(kVK_ANSI_Keypad7)       : VMMLocalizedString(@"Keypad 7"),
+                                @(kVK_F20)                : @"F20",
+                                @(kVK_ANSI_Keypad8)       : VMMLocalizedString(@"Keypad 8"),
+                                @(kVK_ANSI_Keypad9)       : VMMLocalizedString(@"Keypad 9"),
+                                @(kVK_JIS_Yen)            : @"Yen",
+                                @(kVK_JIS_Underscore)     : VMMLocalizedString(@"Underscore"),
+                                @(kVK_JIS_KeypadComma)    : VMMLocalizedString(@"Keypad Comma"),
+                                @(kVK_F5)                 : @"F5",
+                                @(kVK_F6)                 : @"F6",
+                                @(kVK_F7)                 : @"F7",
+                                @(kVK_F3)                 : @"F3",
+                                @(kVK_F8)                 : @"F8",
+                                @(kVK_F9)                 : @"F9",
+                                @(kVK_JIS_Eisu)           : @"Eisu",
+                                @(kVK_F11)                : @"F11",
+                                @(kVK_JIS_Kana)           : @"Kana",
+                                @(kVK_F13)                : @"F13",
+                                @(kVK_F16)                : @"F16",
+                                @(kVK_F14)                : @"F14",
+                                // @(0x6C)                   : @"",
+                                @(kVK_F10)                : @"F10",
+                                @(kVK_ContextMenu)        : VMMLocalizedString(@"Context Menu"),
+                                @(kVK_F12)                : @"F12",
+                                @(kVK_VidMirror)          : VMMLocalizedString(@"Video Mirror"),
+                                @(kVK_F15)                : @"F15",
+                                @(kVK_Help)               : VMMLocalizedString(@"Help"),
+                                @(kVK_Home)               : VMMLocalizedString(@"Home"),
+                                @(kVK_PageUp)             : VMMLocalizedString(@"Page Up"),
+                                @(kVK_ForwardDelete)      : VMMLocalizedString(@"Forward Delete"),
+                                @(kVK_F4)                 : @"F4",
+                                @(kVK_End)                : VMMLocalizedString(@"End"),
+                                @(kVK_F2)                 : @"F2",
+                                @(kVK_PageDown)           : VMMLocalizedString(@"Page Down"),
+                                @(kVK_F1)                 : @"F1",
+                                @(kVK_LeftArrow)          : VMMLocalizedString(@"Left Arrow"),
+                                @(kVK_RightArrow)         : VMMLocalizedString(@"Right Arrow"),
+                                @(kVK_DownArrow)          : VMMLocalizedString(@"Down Arrow"),
+                                @(kVK_UpArrow)            : VMMLocalizedString(@"Up Arrow"),
+                                @(kVK_Power)              : VMMLocalizedString(@"Power"),
+                                // @(0x80)                   : @"",
+                                @(kVK_Spotlight)          : VMMLocalizedString(@"Spotlight"),
+                                @(kVK_Dashboard)          : VMMLocalizedString(@"Dashboard"),
+                                @(kVK_Launchpad)          : VMMLocalizedString(@"Launchpad"),
+                                // @(0x84 ~ 0x8F)            : @"",
+                                @(kVK_BrightnessUp)       : VMMLocalizedString(@"Brightness Up"),
+                                @(kVK_BrightnessDown)     : VMMLocalizedString(@"Brightness Down"),
+                                @(kVK_Eject)              : VMMLocalizedString(@"Eject"),
+                                // @(0x93 ~ 0x9F)            : @"",
+                                @(kVK_ExposesAll)         : VMMLocalizedString(@"Exposes All"),
+                                @(kVK_ExposesDesktop)     : VMMLocalizedString(@"Exposes Desktop"),
+                                // @(0xA2 ~ 0xFF)            : @"",
+                                };
+    }
+    
+    return _virtualKeycodeNames;
+}
++(nullable NSString*)nameOfVirtualKeycode:(CGKeyCode)key
+{
+    return self.virtualKeycodeNames[@(key)];
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMWebView.h
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMWebView.h
@@ -1,0 +1,41 @@
+//
+//  VMMWebView.h
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 30/10/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+#import <WebKit/WebKit.h>
+
+#import "VMMView.h"
+#import "VMMComputerInformation.h"
+
+#define VMMWebViewSupportsHTML5     IS_SYSTEM_MAC_OS_10_9_OR_SUPERIOR
+
+@interface VMMWebViewNavigationBar : VMMView
+@property (nonatomic, strong, nullable) NSTextField* addressBarField;
+@property (nonatomic, strong, nullable) NSButton* refreshButton;
+@end
+
+@interface VMMWebView : VMMView
+
+@property (nonatomic) BOOL hideNavigationBar;
+@property (nonatomic) BOOL urlLoaded;
+@property (nonatomic) BOOL usingWkWebView;
+@property (nonatomic, strong, nullable) NSView* webView;
+@property (nonatomic, strong, nullable) VMMWebViewNavigationBar* navigationBar;
+@property (nonatomic, strong, nullable) NSTextField* webViewErrorLabel;
+
+@property (nonatomic, strong, nullable) NSURL* lastAccessedUrl;
+
+-(void)showErrorMessage:(nonnull NSString*)errorMessage;
+
+-(BOOL)loadURL:(nonnull NSURL*)url;
+-(BOOL)loadURLWithString:(nonnull NSString*)website;
+-(void)loadHTMLString:(nonnull NSString*)htmlPage;
+-(void)loadEmptyPage;
+
+@end
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/VMMWebView.m
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/VMMWebView.m
@@ -1,0 +1,428 @@
+//
+//  VMMWebView.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 30/10/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import "VMMWebView.h"
+
+#import "NSColor+Extension.h"
+#import "NSString+Extension.h"
+#import "NSMutableAttributedString+Extension.h"
+
+#import "VMMComputerInformation.h"
+#import "VMMLocalizationUtility.h"
+
+@implementation VMMWebViewNavigationBar
+@end
+
+@implementation VMMWebView
+
+-(void)setLastAccessedUrl:(NSURL*)lastAccessedUrl
+{
+    _lastAccessedUrl = lastAccessedUrl;
+    
+    if (self.hasNavigationBar)
+    {
+        [_navigationBar.addressBarField setStringValue:_lastAccessedUrl.absoluteString];
+    }
+}
+-(void)setHideNavigationBar:(BOOL)hideNavigationBar
+{
+    _hideNavigationBar = hideNavigationBar;
+    
+    [self reloadWebViewIfNeeded];
+}
+
+// WebView needed delegates
+-(WebView *)webView:(WebView *)sender createWebViewWithRequest:(NSURLRequest *)request
+{
+    self.lastAccessedUrl = request.URL;
+    return sender;
+}
+-(void)webView:(WebView *)webView decidePolicyForNavigationAction:(NSDictionary *)actionInformation request:(NSURLRequest *)request
+         frame:(WebFrame *)frame decisionListener:(id<WebPolicyDecisionListener>)listener
+{
+    NSData* httpBody = request.HTTPBody;
+    
+    NSURL* url = actionInformation[WebActionOriginalURLKey];
+    if (![self shouldLoadUrl:url withHttpBody:httpBody]) return;
+    
+    [listener use];
+}
+
+// WKWebView needed delegates
+- (id)webView:(id)webView createWebViewWithConfiguration:(id)configuration forNavigationAction:(id)navigationAction windowFeatures:(id)windowFeatures
+{
+    NSData* httpBody = ((WKNavigationAction *)navigationAction).request.HTTPBody;
+    
+    self.lastAccessedUrl = ((WKNavigationAction *)navigationAction).request.URL;
+    if (![self shouldLoadUrl:_lastAccessedUrl withHttpBody:httpBody]) return nil;
+    
+    [self loadURL:_lastAccessedUrl];
+    return nil;
+}
+- (void)webView:(id)webView decidePolicyForNavigationAction:(id)navigationAction decisionHandler:(void (^)(NSInteger))decisionHandler
+{
+    NSData* httpBody = ((WKNavigationAction *)navigationAction).request.HTTPBody;
+    
+    NSURL *urlToOpenUrl = ((WKNavigationAction *)navigationAction).request.URL;
+    if (![self shouldLoadUrl:urlToOpenUrl withHttpBody:httpBody])
+    {
+        decisionHandler(WKNavigationActionPolicyCancel);
+    }
+    else
+    {
+        decisionHandler(WKNavigationActionPolicyAllow);
+    }
+}
+- (void)webView:(id)webView didCommitNavigation:(id)navigation
+{
+    self.lastAccessedUrl = [(WKWebView*)self.webView URL];
+}
+
+// Initialization private methods
+-(void)initializeWebView
+{
+    _usingWkWebView = IsClassWKWebViewAvailable;
+    
+    if (_usingWkWebView)
+    {
+        _webView = [[WKWebView alloc] init];
+        WKWebView* webView = (WKWebView*)_webView;
+        
+        webView.UIDelegate = (id<WKUIDelegate>)self;
+        webView.navigationDelegate = (id<WKNavigationDelegate>)self;
+        
+        webView.allowsMagnification = true;
+        
+        [webView setValue:@FALSE forKey:@"opaque"];
+        
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wundeclared-selector"
+        BOOL setDrawsBackgroundExists = [webView respondsToSelector:@selector(_setDrawsBackground:)];
+#pragma GCC diagnostic pop
+        
+        if (setDrawsBackgroundExists)
+        {
+            [webView setValue:@FALSE forKey:@"drawsBackground"];
+        }
+        else
+        {
+            [webView setValue:@TRUE  forKey:@"drawsTransparentBackground"];
+        }
+    }
+    else
+    {
+        _webView = [[WebView alloc] init];
+        WebView* webView = (WebView*)_webView;
+        
+        webView.UIDelegate = (id<WebUIDelegate>)self;
+        webView.policyDelegate = (id<WebPolicyDelegate>)self;
+        webView.frameLoadDelegate = (id<WebFrameLoadDelegate>)self;
+        
+        webView.shouldUpdateWhileOffscreen = false;
+        
+        @try		
+        {		
+            [webView setValue:@FALSE forKey:@"opaque"];		
+        }		
+        @catch (NSException *exception)		
+        {		
+            @try		
+            {		
+                [webView setValue:@FALSE forKey:@"isOpaque"];		
+            }		
+            @catch (NSException *exception) {}		
+        }
+        
+        [webView setValue:@FALSE forKey:@"drawsBackground"];
+    }
+    
+    [self addSubview:_webView];
+    [_webView setAutoresizingMask:NSViewMinYMargin|NSViewMaxXMargin|NSViewMinXMargin|NSViewWidthSizable|NSViewHeightSizable];
+}
+-(void)initializeNavigationBarWithHeight:(CGFloat)navigationBarHeight
+{
+    _navigationBar = [[VMMWebViewNavigationBar alloc] init];
+    
+    [self addSubview:_navigationBar];
+    [_navigationBar setAutoresizingMask:NSViewMinYMargin|NSViewMaxXMargin|NSViewMinXMargin|NSViewWidthSizable];
+    [_navigationBar setBackgroundColor:self.navigationBarColor];
+    
+    NSFont* buttonTextFont = self.navigationBarButtonsTextFont;
+    if (buttonTextFont != nil)
+    {
+        buttonTextFont = [NSFont fontWithDescriptor:buttonTextFont.fontDescriptor size:self.navigationBarButtonsTextSize];
+    }
+    else
+    {
+        buttonTextFont = [NSFont systemFontOfSize:self.navigationBarButtonsTextSize];
+    }
+    
+    NSFont* addressTextFont = self.navigationBarAddressFieldTextFont;
+    if (addressTextFont != nil)
+    {
+        addressTextFont = [NSFont fontWithDescriptor:addressTextFont.fontDescriptor size:self.navigationBarAddressFieldTextSize];
+    }
+    else
+    {
+        addressTextFont = [NSFont systemFontOfSize:self.navigationBarAddressFieldTextSize];
+    }
+    
+    CGFloat fullWidth = _navigationBar.frame.size.width;
+    CGFloat leftMargin = self.navigationBarLeftMargin;
+    
+    _navigationBar.addressBarField = [[NSTextField alloc] init];
+    _navigationBar.refreshButton = [[NSButton alloc] init];
+    [_navigationBar addSubview:_navigationBar.addressBarField];
+    [_navigationBar addSubview:_navigationBar.refreshButton];
+    
+    
+    [_navigationBar.addressBarField setAutoresizingMask:NSViewWidthSizable];
+    [_navigationBar.addressBarField setBordered:NO];
+    [_navigationBar.addressBarField setEditable:NO];
+    [_navigationBar.addressBarField setBackgroundColor:self.navigationBarColor];
+    [_navigationBar.addressBarField setFont:addressTextFont];
+    [_navigationBar.addressBarField setStringValue:VMMLocalizationNotNeeded(@"Tj")];
+    CGFloat addressMaxHeight = _navigationBar.addressBarField.attributedStringValue.size.height;
+    [_navigationBar.addressBarField setFrame:NSMakeRect(leftMargin, (navigationBarHeight - addressMaxHeight)/2,
+                                                        fullWidth - navigationBarHeight - leftMargin, addressMaxHeight)];
+    [_navigationBar.addressBarField setStringValue:@""];
+    
+    
+    [_navigationBar.refreshButton.cell setHighlightsBy:NSNoCellMask];
+    [_navigationBar.refreshButton setBordered:NO];
+    
+    NSMutableAttributedString* title = [[NSMutableAttributedString alloc] initWithString:@"⟳"];
+    [title setFont:buttonTextFont];
+    [title setFontColor:self.navigationBarButtonsTextColor];
+    [_navigationBar.refreshButton setAttributedTitle:title];
+    
+    [_navigationBar.refreshButton setTarget:self];
+    [_navigationBar.refreshButton setAction:@selector(refreshButtonPressed:)];
+    [_navigationBar.refreshButton setAutoresizingMask:NSViewMaxYMargin|NSViewMinYMargin|NSViewMinXMargin];
+    [_navigationBar.refreshButton setFrame:NSMakeRect(fullWidth - navigationBarHeight, 0, navigationBarHeight, navigationBarHeight)];
+}
+-(void)initializeErrorLabel
+{
+    _webViewErrorLabel = [[NSTextField alloc] init];
+    
+    [self addSubview:_webViewErrorLabel];
+    [_webViewErrorLabel setAutoresizingMask:NSViewMaxYMargin|NSViewMinYMargin|NSViewWidthSizable];
+    
+    NSFont* webViewTextFont = self.webViewErrorLabelTextFont;
+    if (webViewTextFont != nil)
+    {
+        webViewTextFont = [NSFont fontWithDescriptor:webViewTextFont.fontDescriptor size:self.webViewErrorLabelTextSize];
+    }
+    else
+    {
+        webViewTextFont = [NSFont systemFontOfSize:self.webViewErrorLabelTextSize];
+    }
+    [_webViewErrorLabel setFont:webViewTextFont];
+    [_webViewErrorLabel setEditable:NO];
+    [_webViewErrorLabel setBordered:NO];
+    [_webViewErrorLabel setSelectable:NO];
+    [_webViewErrorLabel setAlignment:IS_SYSTEM_MAC_OS_10_11_OR_SUPERIOR ? NSTextAlignmentCenter : NSCenterTextAlignment];
+    [_webViewErrorLabel setBackgroundColor:[NSColor clearColor]];
+    [_webViewErrorLabel setTextColor:[NSColor whiteColor]];
+    [self setErrorLabelHidden:YES];
+}
+-(void)initializeOtherComponents
+{
+    
+}
+-(void)reloadWebViewIfNeeded
+{
+    @synchronized(self)
+    {
+        BOOL loadingForTheFirstTime = (_webView == nil);
+        
+        if (_webViewErrorLabel)
+        {
+            [_webViewErrorLabel setStringValue:@""];
+            [self setErrorLabelHidden:YES];
+        }
+        
+        BOOL hasNavigationBar = self.hasNavigationBar;
+        
+        CGFloat width = self.frame.size.width;
+        CGFloat navigationBarHeight = 0;
+        
+        if (hasNavigationBar)
+        {
+            navigationBarHeight = self.navigationBarHeight;
+            if (!_navigationBar) [self initializeNavigationBarWithHeight:navigationBarHeight];
+        }
+        
+        if (loadingForTheFirstTime)
+        {
+            [self initializeWebView];
+            [self initializeErrorLabel];
+        }
+        
+        CGFloat webViewHeight = self.frame.size.height - navigationBarHeight;
+        
+        if (hasNavigationBar)
+        {
+            [_navigationBar setFrame:NSMakeRect(0, webViewHeight, width, navigationBarHeight)];
+        }
+        
+        [_webView setFrame:NSMakeRect(0, 0, width, webViewHeight)];
+        
+        if (loadingForTheFirstTime)
+        {
+            [self initializeOtherComponents];
+        }
+    }
+}
+
+// Private functions
+-(IBAction)refreshButtonPressed:(id)sender
+{
+    [self loadURL:_lastAccessedUrl];
+}
+-(void)setErrorLabelHidden:(BOOL)isHidden
+{
+    _webViewErrorLabel.hidden = isHidden;
+    _webView.hidden = !isHidden;
+    
+    if (isHidden)
+    {
+        [self setBackgroundColor:[NSColor clearColor]];
+    }
+    else
+    {
+        [self setBackgroundColor:[NSColor blackColor]];
+    }
+}
+
+// Private functions that may be overrided
+-(BOOL)hasNavigationBar
+{
+    return _urlLoaded && !_hideNavigationBar;
+}
+-(CGFloat)navigationBarLeftMargin
+{
+    return 20.0;
+}
+-(CGFloat)navigationBarHeight
+{
+    return 45.0;
+}
+-(NSColor*)navigationBarColor
+{
+    if (IS_SYSTEM_MAC_OS_10_14_OR_SUPERIOR) {
+        return [NSColor windowBackgroundColor];
+    }
+    return RGB(209, 207, 209);
+}
+-(NSFont*)navigationBarAddressFieldTextFont
+{
+    return nil;
+}
+-(CGFloat)navigationBarAddressFieldTextSize
+{
+    return 15.0;
+}
+-(NSFont*)navigationBarButtonsTextFont
+{
+    return nil;
+}
+-(CGFloat)navigationBarButtonsTextSize
+{
+    return 30.0;
+}
+-(NSColor*)navigationBarButtonsTextColor
+{
+    return [NSColor blackColor];
+}
+-(NSFont*)webViewErrorLabelTextFont
+{
+    return [NSFont boldSystemFontOfSize:self.webViewErrorLabelTextSize];
+}
+-(CGFloat)webViewErrorLabelTextSize
+{
+    return 25.0;
+}
+-(BOOL)shouldLoadUrl:(NSURL*)urlToOpenUrl withHttpBody:(NSData*)httpBody
+{
+    return YES;
+}
+
+// Public functions
+-(BOOL)loadURL:(nonnull NSURL*)url
+{
+    if (!_usingWkWebView && [url.absoluteString contains:@"://www.youtube.com/v/"])
+    {
+        NSString* mainFolderPluginPath = @"/Library/Internet Plug-Ins/Flash Player.plugin";
+        NSString* userFolderPluginPath = [NSString stringWithFormat:@"%@%@",NSHomeDirectory(),mainFolderPluginPath];
+        
+        if (![[NSFileManager defaultManager] fileExistsAtPath:mainFolderPluginPath] &&
+            ![[NSFileManager defaultManager] fileExistsAtPath:userFolderPluginPath])
+        {
+            [self showErrorMessage:VMMLocalizedString(@"You need Flash Player in order to watch YouTube videos in your macOS version")];
+            return NO;
+        }
+    }
+    
+    _urlLoaded = true;
+    [self reloadWebViewIfNeeded];
+    self.lastAccessedUrl = url;
+    
+    if (_usingWkWebView)
+    {
+        [(WKWebView*)self.webView loadRequest:[NSURLRequest requestWithURL:url]];
+    }
+    else
+    {
+        [((WebView*)self.webView).mainFrame loadRequest:[NSURLRequest requestWithURL:url]];
+    }
+    
+    return YES;
+}
+-(BOOL)loadURLWithString:(nonnull NSString*)website
+{
+    if (![website isAValidURL])
+    {
+        [self showErrorMessage:VMMLocalizedString(@"Invalid URL provided")];
+        return NO;
+    }
+    
+    return [self loadURL:[NSURL URLWithString:website]];
+}
+-(void)loadHTMLString:(nonnull NSString*)htmlPage
+{
+    _urlLoaded = false;
+    [self reloadWebViewIfNeeded];
+    NSURL* url = [NSURL URLWithString:@"about:blank"];
+    
+    if (_usingWkWebView)
+    {
+        [(WKWebView*)self.webView loadHTMLString:htmlPage baseURL:url];
+    }
+    else
+    {
+        [((WebView*)self.webView).mainFrame loadHTMLString:htmlPage baseURL:url];
+    }
+}
+-(void)showErrorMessage:(nonnull NSString*)errorMessage
+{
+    [self loadHTMLString:@"<HTML><BODY bgcolor=\"black\" style=\"margin: 0; padding: 0; height: 100%%; width: 100%%;\" oncontextmenu=\"return false;\"></BODY></HTML>"];
+    
+    [_webViewErrorLabel setStringValue:[errorMessage uppercaseString]];
+    CGFloat textHeight = _webViewErrorLabel.attributedStringValue.size.height;
+    
+    [_webViewErrorLabel setFrame:NSMakeRect(0, (self.frame.size.height - textHeight)/2, self.frame.size.width, textHeight)];
+    [self setErrorLabelHidden:NO];
+}
+-(void)loadEmptyPage
+{
+    [self loadHTMLString:@""];
+}
+
+@end
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/de.lproj/Localizable.strings
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/de.lproj/Localizable.strings
@@ -1,0 +1,43 @@
+/* 
+  Localizable.strings
+  ObjectiveC_Extension
+
+  Created by Vitor Marques de Miranda on 29/09/17.
+  Copyright © 2017 VitorMM. All rights reserved.
+*/
+
+// Misc
+"OK" = "OK";
+"Cancel" = "Abbrechen";
+"Yes" = "Ja";
+"No" = "Nein";
+
+// NSAlert Extension
+"Success" = "Erfolg";
+"Warning" = "Warnung";
+"Error" = "Fehler";
+
+// NSData Extension
+//"Error while reading file data: %@" = "Erro enquanto lia dados de arquivo: %@";
+
+// NSString Extension
+"Error while reading file: %@" = "Fehler beim lesen der Datei: %@";
+"Error while writting file: %@" = "Fehler beim schreiben der Datei: %@";
+
+// NSFileManager Extension
+"Error while creating symbolic link: %@" = "Erro enquanto criava link simbólico: %@";
+"Error while creating folder: %@" = "Fehler beim erstellen des Ordners: %@";
+"Error while moving file: %@" = "Fehler beim bewegen der Datei: %@";
+"Error while copying file: %@" = "Fehler beim kopieren der Datei: %@";
+"Error while removing file: %@" = "Fehler beim entfernen der Datei: %@";
+"Error while listing folder contents: %@" = "Fehler beim auflisten des Ordnerinhaltes von: %@";
+//"Error while listing folder contents: %@ doesn't exist." = "Erro enquanto listava o conteúdo de pasta: %@ não existe.";
+//"Error while listing folder contents: %@ is not a folder." = "Erro enquanto listava o conteúdo de pasta: %@ não é uma pasta.";
+//"Error while retrieving symbolic link destination: %@" = "Erro enquanto obtia destino de link simbólico: %@";
+
+// NSTask Extension
+//"Path for %@ not found." = "Caminho para %@ não encontrado.";
+//"File %@ not found." = "Arquivo %@ não encontrado.";
+//"File %@ not runnable." = "Arquivo %@ não é executável.";
+//"Directory %@ does not exists." = "Diretório %@ não existe.";
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/en.lproj/Localizable.strings
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/en.lproj/Localizable.strings
@@ -1,0 +1,211 @@
+/* 
+  Localizable.strings
+  ObjectiveC_Extension
+
+  Created by Vitor Marques de Miranda on 29/09/17.
+  Copyright © 2017 VitorMM. All rights reserved.
+*/
+
+/*
+// Misc
+"OK" = "OK";
+"Cancel" = "Cancelar";
+"Yes" = "Sim";
+"No" = "Não";
+
+// VMMUsageKeycode
+"Error Roll Over" = "Encerramento de Erro";
+"Post Fail" = "Pós-Falha";
+"Error Undefined" = "Erro Indefinido";
+"Return" = "Return";
+"Escape" = "Esc";
+"Delete" = "Delete";
+"Tab" = "Tab";
+"Space" = "Espaço";
+"Minus" = "Menos";
+"Equal" = "Igual";
+"Left Bracket" = "Colchete Esquerdo";
+"Right Bracket" = "Colchete Direito";
+"Backslash" = "Contra-Barra";
+"Pound" = "Libra";
+"Semicolon" = "Ponto e vírgula";
+"Quote" = "Aspas";
+"Grave" = "Crase";
+"Comma" = "Vírgula";
+"Period" = "Ponto";
+"Slash" = "Barra";
+"Caps Lock" = "Caps Lock";
+"Print Screen" = "Print Screen";
+"Scroll Lock" = "Scroll Lock";
+"Pause" = "Pause";
+"Insert" = "Insert";
+"Home" = "Home";
+"Page Up" = "Page Up";
+"Forward Delete" = "Forward Delete";
+"End" = "End";
+"Page Down" = "Page Down";
+"Right Arrow" = "Seta Direita";
+"Left Arrow" = "Seta Esquerda";
+"Down Arrow" = "Seta Baixo";
+"Up Arrow" = "Seta Cima";
+"Keypad Clear" = "";
+"Keypad Divide" = "";
+"Keypad Multiply" = "";
+"Keypad Minus" = "";
+"Keypad Plus" = "";
+"Keypad Enter" = "";
+"Keypad 1" = "";
+"Keypad 2" = "";
+"Keypad 3" = "";
+"Keypad 4" = "";
+"Keypad 5" = "";
+"Keypad 6" = "";
+"Keypad 7" = "";
+"Keypad 8" = "";
+"Keypad 9" = "";
+"Keypad 0" = "";
+"Keypad Decimal" = "";
+"Backslash" = "";
+"Application" = "";
+"Power" = "";
+"Keypad Equals" = "";
+"Execute" = "";
+"Help" = "";
+"Context Menu" = "";
+"Select" = "";
+"Stop" = "";
+"Again" = "";
+"Undo" = "";
+"Cut" = "";
+"Copy" = "";
+"Paste" = "";
+"Find" = "";
+"Mute" = "";
+"Volume Up" = "";
+"Volume Down" = "";
+"Locking Caps Lock" = "";
+"Locking Num Lock" = "";
+"Locking Scroll Lock" = "";
+"Keypad Comma" = "";
+"Keypad Equal" = "";
+"Hangul/English" = "";
+"Conversion Hanja" = "";
+"Zankaku or Hankaku" = "";
+"Alternate Erase" = "";
+"SysReq or Attention" = "";
+"Cancel" = "";
+"Clear" = "";
+"Prior" = "";
+"Return" = "";
+"Separator" = "";
+"Out" = "";
+"Oper" = "";
+"Clear or Again" = "";
+"CrSel or Props" = "";
+"ExSel" = "";
+"Keypad Zero Zero" = "";
+"Keypad Zero Zero Zero" = "";
+"Keypad Thousands Separator" = "";
+"Keypad Decimal Separator" = "";
+"Keypad Currency Unit" = "";
+"Keypad Currency Subunit" = "";
+"Keypad Left Parentheses" = "";
+"Keypad Right Parentheses" = "";
+"Keypad Left Braces" = "";
+"Keypad Right Braces" = "";
+"Keypad Tab" = "";
+"Keypad Backspace" = "";
+"Keypad A" = "";
+"Keypad B" = "";
+"Keypad C" = "";
+"Keypad D" = "";
+"Keypad E" = "";
+"Keypad F" = "";
+"Keypad XOR" = "";
+"Keypad Circumflex" = "";
+"Keypad Percent" = "";
+"Keypad Less Than" = "";
+"Keypad More Than" = "";
+"Keypad Ampersand" = "";
+"Keypad Ampersand Ampersand" = "";
+"Keypad Vertical Line" = "";
+"Keypad Two Vertical Lines" = "";
+"Keypad Colon" = "";
+"Keypad Number Sign" = "";
+"Keypad Space" = "";
+"Keypad Commercial At" = "";
+"Keypad Exclamation" = "";
+"Keypad Memory Store" = "";
+"Keypad Memory Recall" = "";
+"Keypad Memory Clear" = "";
+"Keypad Memory Add" = "";
+"Keypad Memory Substract" = "";
+"Keypad Memory Multiply" = "";
+"Keypad Memory Divide" = "";
+"Keypad Plus Minus" = "";
+"Keypad Clear" = "";
+"Keypad Clear Entry" = "";
+"Keypad Binary" = "";
+"Keypad Octal" = "";
+"Keypad Decimal" = "";
+"Keypad Hexadecimal" = "";
+"Left Control" = "";
+"Left Shift" = "";
+"Left Option" = "";
+"Left Command" = "";
+"Right Control" = "";
+"Right Shift" = "";
+"Right Option" = "";
+"Right Command" = "";
+"Play" = "";
+"Function" = "";
+"Next" = "";
+"Previous" = "";
+"Underscore" = "";
+"Video Mirror" = "";
+"Spotlight" = "";
+"Dashboard" = "";
+"Launchpad" = "";
+"Brightness Up" = "";
+"Brightness Down" = "";
+"Eject" = "";
+"Exposes All" = "";
+"Exposes Desktop" = "";
+ 
+// NSAlert Extension
+"Success" = "Sucesso";
+"Warning" = "Aviso";
+"Error" = "Erro";
+
+// NSData Extension
+"Error while loading file data: %@" = "Erro enquanto carregava dados de arquivo: %@";
+
+// NSFileManager Extension
+"Error while creating symbolic link: %@" = "Erro enquanto criava link simbólico: %@";
+"Error while creating folder: %@" = "Erro enquanto criava pasta: %@";
+"Error while moving file: %@" = "Erro enquanto movia arquivo: %@";
+"Error while copying file: %@" = "Erro enquanto copiava arquivo: %@";
+"Error while removing file: %@" = "Erro enquanto removia arquivo: %@";
+"Error while listing folder contents: %@ doesn't exist." = "Erro enquanto listava o conteúdo de pasta: %@ não existe.";
+"Error while listing folder contents: %@ is not a folder." = "Erro enquanto listava o conteúdo de pasta: %@ não é uma pasta.";
+"Error while listing folder contents: %@" = "Erro enquanto listava o conteúdo de pasta: %@";
+"Error while retrieving symbolic link destination: %@" = "Erro enquanto obtia destino de link simbólico: %@";
+
+// NSString Extension
+"Error while reading file: %@" = "Erro enquanto lia arquivo: %@";
+"Error while writting file: %@" = "Erro enquanto escrevia arquivo: %@";
+
+// NSTask Extension
+"Path for %@ not found." = "Caminho para %@ não encontrado.";
+"File %@ not found." = "Arquivo %@ não encontrado.";
+"File %@ not runnable." = "Arquivo %@ não é executável.";
+"Directory %@ does not exists." = "Diretório %@ não existe.";
+
+// VMMWebView
+"You need Flash Player in order to watch YouTube videos in your macOS version" = "Você precisa do Flash Player para assistir vídeos do YouTube na sua versão do macOS";
+"Invalid URL provided" = "URL inválida provida";
+ 
+// VMMKeyCaptureField
+"Unknown Key (%d)" = "Tecla Desconhecida (%d)";
+ 
+*/

--- a/ObjectiveC_Extension/ObjectiveC_Extension/fr.lproj/Localizable.strings
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/fr.lproj/Localizable.strings
@@ -1,0 +1,43 @@
+/* 
+  Localizable.strings
+  ObjectiveC_Extension
+
+  Created by Vitor Marques de Miranda on 29/09/17.
+  Copyright © 2017 VitorMM. All rights reserved.
+*/
+
+// Misc
+"OK" = "OK";
+"Cancel" = "Annuler";
+"Yes" = "Oui";
+"No" = "Non";
+
+// NSAlert Extension
+"Success" = "Succès";
+"Warning" = "Attention";
+"Error" = "Erreur";
+
+// NSData Extension
+//"Error while reading file data: %@" = "Erro enquanto lia dados de arquivo: %@";
+
+// NSString Extension
+"Error while reading file: %@" = "Erreur lors de la lecture du fichier: %@";
+"Error while writting file: %@" = "Erreur lors de l'écriture du fichier: %@";
+
+// NSFileManager Extension
+"Error while creating symbolic link: %@" = "Erreur lors de la création d'un lien symbolique: %@";
+"Error while creating folder: %@" = "Erreur lors de la création du dossier: %@";
+"Error while moving file: %@" = "Erreur lors du déplacement du fichier: %@";
+"Error while copying file: %@" = "Erreur lors de la copie du fichier: %@";
+"Error while removing file: %@" = "Erreur lors de la suppression du fichier: %@";
+"Error while listing folder contents: %@" = "Erreur lors du listage du contenu du dossier: %@";
+//"Error while listing folder contents: %@ doesn't exist." = "Erro enquanto listava o conteúdo de pasta: %@ não existe.";
+//"Error while listing folder contents: %@ is not a folder." = "Erro enquanto listava o conteúdo de pasta: %@ não é uma pasta.";
+//"Error while retrieving symbolic link destination: %@" = "Erro enquanto obtia destino de link simbólico: %@";
+
+// NSTask Extension
+//"Path for %@ not found." = "Caminho para %@ não encontrado.";
+//"File %@ not found." = "Arquivo %@ não encontrado.";
+//"File %@ not runnable." = "Arquivo %@ não é executável.";
+//"Directory %@ does not exists." = "Diretório %@ não existe.";
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/nl.lproj/Localizable.strings
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/nl.lproj/Localizable.strings
@@ -1,0 +1,43 @@
+/* 
+  Localizable.strings
+  ObjectiveC_Extension
+
+  Created by Vitor Marques de Miranda on 29/09/17.
+  Copyright © 2017 VitorMM. All rights reserved.
+*/
+
+// Misc
+"OK" = "OK";
+"Cancel" = "Annuleren";
+"Yes" = "Ja";
+"No" = "Nee";
+
+// NSAlert Extension
+"Success" = "Success";
+"Warning" = "Waarschuwing";
+"Error" = "Error";
+
+// NSData Extension
+//"Error while reading file data: %@" = "Erro enquanto lia dados de arquivo: %@";
+
+// NSString Extension
+"Error while reading file: %@" = "Fout tijdens lezen van bestand: %@";
+"Error while writting file: %@" = "Fout tijdens schrijven van bestand: %@";
+
+// NSFileManager Extension
+"Error while creating symbolic link: %@" = "Fout tijdens aanmaken symbolische link: %@";
+"Error while creating folder: %@" = "Fout tijdens aanmaken map: %@";
+"Error while moving file: %@" = "Fout tijdens verplaatsen bestand: %@";
+"Error while copying file: %@" = "Fout tijdens kopiëren bestand: %@";
+"Error while removing file: %@" = "Fout tijdens verwijderen bestand: %@";
+"Error while listing folder contents: %@" = "Fout tijdens opmaken inhoud folder: %@";
+//"Error while listing folder contents: %@ doesn't exist." = "Erro enquanto listava o conteúdo de pasta: %@ não existe.";
+//"Error while listing folder contents: %@ is not a folder." = "Erro enquanto listava o conteúdo de pasta: %@ não é uma pasta.";
+"Error while retrieving symbolic link destination: %@" = "Error tijdens het checken van de symbolische link bestemming %@";
+
+// NSTask Extension
+//"Path for %@ not found." = "Caminho para %@ não encontrado.";
+"File %@ not found." = "Bestand %@ niet gevonden.";
+"File %@ not runnable." = "Bestand %@ niet uitvoerbaar.";
+//"Directory %@ does not exists." = "Diretório %@ não existe.";
+

--- a/ObjectiveC_Extension/ObjectiveC_Extension/pt-BR.lproj/Localizable.strings
+++ b/ObjectiveC_Extension/ObjectiveC_Extension/pt-BR.lproj/Localizable.strings
@@ -1,0 +1,43 @@
+/* 
+  Localizable.strings
+  ObjectiveC_Extension
+
+  Created by Vitor Marques de Miranda on 29/09/17.
+  Copyright © 2017 VitorMM. All rights reserved.
+*/
+
+// Misc
+"OK" = "OK";
+"Cancel" = "Cancelar";
+"Yes" = "Sim";
+"No" = "Não";
+
+// NSAlert Extension
+"Success" = "Sucesso";
+"Warning" = "Aviso";
+"Error" = "Erro";
+
+// NSData Extension
+"Error while reading file data: %@" = "Erro enquanto lia dados de arquivo: %@";
+
+// NSString Extension
+"Error while reading file: %@" = "Erro enquanto lia arquivo: %@";
+"Error while writting file: %@" = "Erro enquanto escrevia arquivo: %@";
+
+// NSFileManager Extension
+"Error while creating symbolic link: %@" = "Erro enquanto criava link simbólico: %@";
+"Error while creating folder: %@" = "Erro enquanto criava pasta: %@";
+"Error while moving file: %@" = "Erro enquanto movia arquivo: %@";
+"Error while copying file: %@" = "Erro enquanto copiava arquivo: %@";
+"Error while removing file: %@" = "Erro enquanto removia arquivo: %@";
+"Error while listing folder contents: %@" = "Erro enquanto listava o conteúdo de pasta: %@";
+"Error while listing folder contents: %@ doesn't exist." = "Erro enquanto listava o conteúdo de pasta: %@ não existe.";
+"Error while listing folder contents: %@ is not a folder." = "Erro enquanto listava o conteúdo de pasta: %@ não é uma pasta.";
+"Error while retrieving symbolic link destination: %@" = "Erro enquanto obtia destino de link simbólico: %@";
+
+// NSTask Extension
+"Path for %@ not found." = "Caminho para %@ não encontrado.";
+"File %@ not found." = "Arquivo %@ não encontrado.";
+"File %@ not runnable." = "Arquivo %@ não é executável.";
+"Directory %@ does not exists." = "Diretório %@ não existe.";
+

--- a/ObjectiveC_Extension/ObjectiveC_ExtensionTests/Info.plist
+++ b/ObjectiveC_Extension/ObjectiveC_ExtensionTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/ObjectiveC_Extension/ObjectiveC_ExtensionTests/NSArrayTests.m
+++ b/ObjectiveC_Extension/ObjectiveC_ExtensionTests/NSArrayTests.m
@@ -1,0 +1,95 @@
+//
+//  NSArrayTests.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 15/05/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "NSArray+Extension.h"
+
+@interface NSArrayTests : XCTestCase
+
+@end
+
+@implementation NSArrayTests
+
+- (void)testSortedDictionariesArrayWithKeyOrderingByValuesOrder
+{
+    NSString* key   = @"Bus";
+    NSArray* order  = @[@"PCIe", @"PCI", @"Built-In"];
+    
+    NSMutableArray* input = [@[@{key: @"PCIe"}, @{key: @"Built-In"}, @{key: @"PCI"}] mutableCopy];
+    NSArray* output       =  @[@{key: @"PCIe"}, @{key: @"PCI"}, @{key: @"Built-In"}];
+    
+    [input sortDictionariesWithKey:key orderingByValuesOrder:order];
+    XCTAssert([input isEqualToArray:output]);
+}
+
+- (void)testArrayByRemovingRepetitions_noChange
+{
+    NSArray* originalArray = @[@1,@2,@3,@4,@5,@6];
+    NSArray* resultArray = [originalArray arrayByRemovingRepetitions];
+    
+    XCTAssert(resultArray.count == 6);
+    XCTAssert([resultArray containsObject:@1]);
+    XCTAssert([resultArray containsObject:@2]);
+    XCTAssert([resultArray containsObject:@3]);
+    XCTAssert([resultArray containsObject:@4]);
+    XCTAssert([resultArray containsObject:@5]);
+    XCTAssert([resultArray containsObject:@6]);
+}
+- (void)testArrayByRemovingRepetitions_fromSixToThreeResults
+{
+    NSArray* originalArray = @[@1,@2,@1,@2,@1,@4];
+    NSArray* resultArray = [originalArray arrayByRemovingRepetitions];
+    
+    XCTAssert(resultArray.count == 3);
+    XCTAssert([resultArray containsObject:@1]);
+    XCTAssert([resultArray containsObject:@2]);
+    XCTAssert([resultArray containsObject:@4]);
+}
+- (void)testArrayByRemovingRepetitions_oneResultOnly
+{
+    NSArray* originalArray = @[@1,@1,@1,@1,@1,@1];
+    NSArray* resultArray = [originalArray arrayByRemovingRepetitions];
+    
+    XCTAssert(resultArray.count == 1);
+    XCTAssert([resultArray containsObject:@1]);
+}
+
+- (void)testArrayByRemovingObjectsFromArray_removeTwoFromFive
+{
+    NSArray* originalArray = @[@1,@2,@3,@4,@5];
+    NSArray* itemsToRemove = @[@2,@5];
+    NSArray* result = [originalArray arrayByRemovingObjectsFromArray:itemsToRemove];
+    
+    XCTAssert(resultArray.count == 3);
+    XCTAssert([resultArray containsObject:@1]);
+    XCTAssert([resultArray containsObject:@3]);
+    XCTAssert([resultArray containsObject:@4]);
+}
+- (void)testArrayByRemovingObjectsFromArray_removeAll
+{
+    NSArray* originalArray = @[@1,@2,@3,@4,@5];
+    NSArray* itemsToRemove = @[@4,@3,@2,@1,@5];
+    NSArray* result = [originalArray arrayByRemovingObjectsFromArray:itemsToRemove];
+    
+    XCTAssert(resultArray.count == 0);
+}
+- (void)testArrayByRemovingObjectsFromArray_removeNothing
+{
+    NSArray* originalArray = @[@1,@2,@3,@4,@5];
+    NSArray* itemsToRemove = @[@7,@8];
+    NSArray* result = [originalArray arrayByRemovingObjectsFromArray:itemsToRemove];
+    
+    XCTAssert(resultArray.count == 5);
+    XCTAssert([resultArray containsObject:@1]);
+    XCTAssert([resultArray containsObject:@2]);
+    XCTAssert([resultArray containsObject:@3]);
+    XCTAssert([resultArray containsObject:@4]);
+    XCTAssert([resultArray containsObject:@5]);
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_ExtensionTests/NSColorTests.m
+++ b/ObjectiveC_Extension/ObjectiveC_ExtensionTests/NSColorTests.m
@@ -1,0 +1,34 @@
+//
+//  NSColorTests.m
+//  ObjectiveC_ExtensionTests
+//
+//  Created by Vitor Marques de Miranda on 14/11/2017.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "NSColor+Extension.h"
+
+@interface NSColorTests : XCTestCase
+
+@end
+
+@implementation NSColorTests
+
+-(void)testColorWithHexColorString
+{
+    NSColor* redColor = [NSColor colorWithHexColorString:@"FF0000"];
+    
+    XCTAssert(redColor.redComponent - 255 < 0.1);
+    XCTAssert(redColor.greenComponent < 0.1);
+    XCTAssert(redColor.blueComponent < 0.1);
+}
+-(void)testHexColorString
+{
+    NSColor* redColor = [NSColor redColor];
+    NSString* redColorHex = [redColor hexColorString];
+    
+    XCTAssert([redColorHex isEqualToString:@"FF0000"]);
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_ExtensionTests/NSStringTests.m
+++ b/ObjectiveC_Extension/ObjectiveC_ExtensionTests/NSStringTests.m
@@ -1,0 +1,205 @@
+//
+//  NSStringTests.m
+//  ObjectiveC_Extension
+//
+//  Created by Vitor Marques de Miranda on 15/05/17.
+//  Copyright © 2017 Vitor Marques de Miranda. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "NSString+Extension.h"
+
+@interface NSStringTests : XCTestCase
+
+@end
+
+@implementation NSStringTests
+
+- (void)testStringContains
+{
+    XCTAssert(![@"12345678" contains:@""]);
+    XCTAssert( [@"12345678" contains:@"123"]);
+    XCTAssert(![@"12345678" contains:@"321"]);
+}
+
+- (void)testStringWithHexString
+{
+    XCTAssert([[NSString stringWithHexadecimalUTF8String:@"42"] isEqualToString:@"B"]);
+}
+
+- (void)testStringByRemovingEvenCharsFromString
+{
+    XCTAssert([[NSString stringByRemovingEvenCharsFromString:@"12345678"] isEqualToString:@"1357"]);
+}
+
+- (void)testStringWebStructure
+{
+    XCTAssert([[@"?" stringToWebStructure] isEqualToString:@"%3F"]);
+    XCTAssert([[@"<" stringToWebStructure] isEqualToString:@"%3C"]);
+    XCTAssert([[@"&" stringToWebStructure] isEqualToString:@"%26"]);
+    XCTAssert([[@"%" stringToWebStructure] isEqualToString:@"%25"]);
+    XCTAssert([[@" " stringToWebStructure] isEqualToString:@"%20"]);
+    
+    XCTAssert([[@"\n" stringToWebStructure] isEqualToString:@"%0A"]);
+    XCTAssert([[@"\t" stringToWebStructure] isEqualToString:@"%09"]);
+    
+    XCTAssert([[@"B" stringToWebStructure] isEqualToString:@"B"]);
+    XCTAssert([[@"+" stringToWebStructure] isEqualToString:@"%2B"]);
+    XCTAssert([[@"=" stringToWebStructure] isEqualToString:@"%3D"]);
+}
+
+- (void)testStringRangeAfterAndBefore
+{
+    // With Before and End in the String; With Before and End arguments
+    XCTAssert([@"012345678X0123Y5" rangeAfterString:@"X" andBeforeString:@"Y"].location == 10);
+    XCTAssert([@"012345678X0123Y5" rangeAfterString:@"X" andBeforeString:@"Y"].length == 4);
+    
+    // With Before and End in the String; With Before argument only
+    XCTAssert([@"012345678X0123Y5" rangeAfterString:@"X" andBeforeString:nil].location == 10);
+    XCTAssert([@"012345678X0123Y5" rangeAfterString:@"X" andBeforeString:nil].length == 6);
+    
+    // With Before and End in the String; With After argument only
+    XCTAssert([@"012345678X0123Y5" rangeAfterString:nil andBeforeString:@"Y"].location == 0);
+    XCTAssert([@"012345678X0123Y5" rangeAfterString:nil andBeforeString:@"Y"].length == 14);
+    
+    // With Before and End in the String; With no arguments
+    XCTAssert([@"012345678X0123Y5" rangeAfterString:nil andBeforeString:nil].location == 0);
+    XCTAssert([@"012345678X0123Y5" rangeAfterString:nil andBeforeString:nil].length == 16);
+    
+    
+    
+    // With Before in the String; With Before and End arguments
+    XCTAssert([@"012345678X012345" rangeAfterString:@"X" andBeforeString:@"Y"].location == 10);
+    XCTAssert([@"012345678X012345" rangeAfterString:@"X" andBeforeString:@"Y"].length == 6);
+    
+    // With Before in the String; With Before argument only
+    XCTAssert([@"012345678X012345" rangeAfterString:@"X" andBeforeString:nil].location == 10);
+    XCTAssert([@"012345678X012345" rangeAfterString:@"X" andBeforeString:nil].length == 6);
+    
+    // With Before in the String; With After argument only
+    XCTAssert([@"012345678X012345" rangeAfterString:nil andBeforeString:@"Y"].location == 0);
+    XCTAssert([@"012345678X012345" rangeAfterString:nil andBeforeString:@"Y"].length == 16);
+    
+    // With Before in the String; With no arguments
+    XCTAssert([@"012345678X012345" rangeAfterString:nil andBeforeString:nil].location == 0);
+    XCTAssert([@"012345678X012345" rangeAfterString:nil andBeforeString:nil].length == 16);
+    
+    
+    
+    // With End in the String; With Before and End arguments
+    XCTAssert([@"01234567890123Y5" rangeAfterString:@"X" andBeforeString:@"Y"].location == NSNotFound);
+    
+    // With End in the String; With Before argument only
+    XCTAssert([@"01234567890123Y5" rangeAfterString:@"X" andBeforeString:nil].location == NSNotFound);
+    
+    // With End in the String; With After argument only
+    XCTAssert([@"01234567890123Y5" rangeAfterString:nil andBeforeString:@"Y"].location == 0);
+    XCTAssert([@"01234567890123Y5" rangeAfterString:nil andBeforeString:@"Y"].length == 14);
+    
+    // With End in the String; With no arguments
+    XCTAssert([@"01234567890123Y5" rangeAfterString:nil andBeforeString:nil].location == 0);
+    XCTAssert([@"01234567890123Y5" rangeAfterString:nil andBeforeString:nil].length == 16);
+    
+    
+    
+    // With End in the String; With Before and End arguments
+    XCTAssert([@"0123456789012345" rangeAfterString:@"X" andBeforeString:@"Y"].location == NSNotFound);
+    
+    // With End in the String; With Before argument only
+    XCTAssert([@"0123456789012345" rangeAfterString:@"X" andBeforeString:nil].location == NSNotFound);
+    
+    // With End in the String; With After argument only
+    XCTAssert([@"0123456789012345" rangeAfterString:nil andBeforeString:@"Y"].location == 0);
+    XCTAssert([@"0123456789012345" rangeAfterString:nil andBeforeString:@"Y"].length == 16);
+    
+    // With End in the String; With no arguments
+    XCTAssert([@"0123456789012345" rangeAfterString:nil andBeforeString:nil].location == 0);
+    XCTAssert([@"0123456789012345" rangeAfterString:nil andBeforeString:nil].length == 16);
+}
+
+- (void)testInitialIntValue
+{
+    XCTAssert([@"10421ab" initialIntegerValue].intValue == 10421);
+    XCTAssert([@"10421a"  initialIntegerValue].intValue == 10421);
+    XCTAssert([@"10421&"  initialIntegerValue].intValue == 10421);
+    XCTAssert([@"10421."  initialIntegerValue].intValue == 10421);
+    XCTAssert([@"10421%"  initialIntegerValue].intValue == 10421);
+    XCTAssert([@"10421"   initialIntegerValue].intValue == 10421);
+    XCTAssert([@"abc"     initialIntegerValue] == nil           );
+}
+
+- (void)testGetFragment
+{
+    // With Before and End in the String; With Before and End arguments
+    XCTAssert([[@"012345678X0123Y5" getFragmentAfter:@"X" andBefore:@"Y"] isEqualToString:@"0123"]);
+    
+    // With Before and End in the String; With Before argument only
+    XCTAssert([[@"012345678X0123Y5" getFragmentAfter:@"X" andBefore:nil] isEqualToString:@"0123Y5"]);
+    
+    // With Before and End in the String; With After argument only
+    XCTAssert([[@"012345678X0123Y5" getFragmentAfter:nil andBefore:@"Y"] isEqualToString:@"012345678X0123"]);
+    
+    // With Before and End in the String; With no arguments
+    XCTAssert([[@"012345678X0123Y5" getFragmentAfter:nil andBefore:nil] isEqualToString:@"012345678X0123Y5"]);
+    
+    
+    
+    // With Before in the String; With Before and End arguments
+    XCTAssert([[@"012345678X012345" getFragmentAfter:@"X" andBefore:@"Y"] isEqualToString:@"012345"]);
+    
+    // With Before in the String; With Before argument only
+    XCTAssert([[@"012345678X012345" getFragmentAfter:@"X" andBefore:nil] isEqualToString:@"012345"]);
+    
+    // With Before in the String; With After argument only
+    XCTAssert([[@"012345678X012345" getFragmentAfter:nil andBefore:@"Y"] isEqualToString:@"012345678X012345"]);
+    
+    // With Before in the String; With no arguments
+    XCTAssert([[@"012345678X012345" getFragmentAfter:nil andBefore:nil] isEqualToString:@"012345678X012345"]);
+    
+    
+    
+    // With End in the String; With Before and End arguments
+    XCTAssert([@"01234567890123Y5" getFragmentAfter:@"X" andBefore:@"Y"] == nil);
+    
+    // With End in the String; With Before argument only
+    XCTAssert([@"01234567890123Y5" getFragmentAfter:@"X" andBefore:nil] == nil);
+    
+    // With End in the String; With After argument only
+    XCTAssert([[@"01234567890123Y5" getFragmentAfter:nil andBefore:@"Y"] isEqualToString:@"01234567890123"]);
+    
+    // With End in the String; With no arguments
+    XCTAssert([[@"01234567890123Y5" getFragmentAfter:nil andBefore:nil] isEqualToString:@"01234567890123Y5"]);
+    
+    
+    
+    // Without both in the String; With Before and End arguments
+    XCTAssert([@"0123456789012345" getFragmentAfter:@"X" andBefore:@"Y"] == nil);
+    
+    // Without both in the String; With Before argument only
+    XCTAssert([@"0123456789012345" getFragmentAfter:@"X" andBefore:nil] == nil);
+    
+    // Without both in the String; With After argument only
+    XCTAssert([[@"0123456789012345" getFragmentAfter:nil andBefore:@"Y"] isEqualToString:@"0123456789012345"]);
+    
+    // Without both in the String; With no arguments
+    XCTAssert([[@"0123456789012345" getFragmentAfter:nil andBefore:nil] isEqualToString:@"0123456789012345"]);
+}
+
+- (void)testComponentsMatchingWithRegex
+{
+    NSArray* result;
+    
+    result = @[@"1",@"2",@"3",@"4",@"5",@"6",@"7",@"8",@"9",@"0"];
+    XCTAssert([[@"1234567890" componentsMatchingWithRegex:@"[0-9]"] isEqualToArray:result]);
+    
+    result = @[@"1234567890"];
+    XCTAssert([[@"1234567890" componentsMatchingWithRegex:@"[0-9]{10}"] isEqualToArray:result]);
+    
+    result = @[@"123a",@"456b",@"789c"];
+    XCTAssert([[@"123a456b789c" componentsMatchingWithRegex:@"[0-9]{3}[a-z]"] isEqualToArray:result]);
+    
+    result = @[@"1234567890"];
+    XCTAssert([[@"1234567890" componentsMatchingWithRegex:@"[0-9]+"] isEqualToArray:result]);
+}
+
+@end

--- a/ObjectiveC_Extension/ObjectiveC_ExtensionTests/ObjectiveC_ExtensionTests.m
+++ b/ObjectiveC_Extension/ObjectiveC_ExtensionTests/ObjectiveC_ExtensionTests.m
@@ -1,0 +1,39 @@
+//
+//  ObjectiveC_ExtensionTests.m
+//  ObjectiveC_ExtensionTests
+//
+//  Created by Vitor Marques de Miranda on 29/09/17.
+//  Copyright © 2017 VitorMM. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface ObjectiveC_ExtensionTests : XCTestCase
+
+@end
+
+@implementation ObjectiveC_ExtensionTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/Wineskin Winery/Wineskin Winery.xcodeproj/project.pbxproj
+++ b/Wineskin Winery/Wineskin Winery.xcodeproj/project.pbxproj
@@ -13,30 +13,12 @@
 		8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
-		A1001B6D242FEA1000308B79 /* ObjectiveC_Extension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1001B6A242FEA0900308B79 /* ObjectiveC_Extension.framework */; };
-		A1001B6E242FEA1000308B79 /* ObjectiveC_Extension.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A1001B6A242FEA0900308B79 /* ObjectiveC_Extension.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A1DD87612495907800E4D0DE /* 7za in Resources */ = {isa = PBXBuildFile; fileRef = A1DD87602495906B00E4D0DE /* 7za */; };
 		A89936DE127B283A006A7581 /* WineskinWineryUpdater in Resources */ = {isa = PBXBuildFile; fileRef = A89936DD127B283A006A7581 /* WineskinWineryUpdater */; };
 		A89E94A6153EE960006F38DB /* WineskinBanner.jpg in Resources */ = {isa = PBXBuildFile; fileRef = A89E94A5153EE960006F38DB /* WineskinBanner.jpg */; };
 		A8A76BB114E46AB700F2C8D0 /* Winery.icns in Resources */ = {isa = PBXBuildFile; fileRef = A8A76BB014E46AB700F2C8D0 /* Winery.icns */; };
+		C073C6B32C7B9E3D00EB7E31 /* ObjectiveC_Extension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17F79DF23DE4345006FF8D2 /* ObjectiveC_Extension.framework */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		A1001B69242FEA0900308B79 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A1001B64242FEA0900308B79 /* ObjectiveC_Extension.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 4E6C51071F7E8EB700A187E9;
-			remoteInfo = ObjectiveC_Extension;
-		};
-		A1001B6B242FEA0900308B79 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A1001B64242FEA0900308B79 /* ObjectiveC_Extension.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 4E6C51101F7E8EB700A187E9;
-			remoteInfo = ObjectiveC_ExtensionTests;
-		};
-/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		A1001B6F242FEA1100308B79 /* Embed Frameworks */ = {
@@ -45,7 +27,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				A1001B6E242FEA1000308B79 /* ObjectiveC_Extension.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -65,7 +46,6 @@
 		4E45371F20E7DA16005D794E /* NSWineskinEngine.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSWineskinEngine.m; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* Wineskin_Winery-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Wineskin_Winery-Info.plist"; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* Wineskin Winery.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Wineskin Winery.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		A1001B64242FEA0900308B79 /* ObjectiveC_Extension.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ObjectiveC_Extension.xcodeproj; path = ../../ObjectiveC_Extension/ObjectiveC_Extension.xcodeproj; sourceTree = "<group>"; };
 		A17F79DF23DE4345006FF8D2 /* ObjectiveC_Extension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ObjectiveC_Extension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1A81DBF24A7B81A00062104 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		A1A81DC124A7B81F00062104 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -80,7 +60,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A1001B6D242FEA1000308B79 /* ObjectiveC_Extension.framework in Frameworks */,
+				C073C6B32C7B9E3D00EB7E31 /* ObjectiveC_Extension.framework in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -128,7 +108,6 @@
 		29B97314FDCFA39411CA2CEA /* Wineskin Winery */ = {
 			isa = PBXGroup;
 			children = (
-				A1001B64242FEA0900308B79 /* ObjectiveC_Extension.xcodeproj */,
 				080E96DDFE201D6D7F000001 /* Classes */,
 				29B97315FDCFA39411CA2CEA /* Other Sources */,
 				29B97317FDCFA39411CA2CEA /* Resources */,
@@ -169,15 +148,6 @@
 				1058C7A2FEA54F0111CA2CBB /* Other Frameworks */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		A1001B65242FEA0900308B79 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				A1001B6A242FEA0900308B79 /* ObjectiveC_Extension.framework */,
-				A1001B6C242FEA0900308B79 /* ObjectiveC_ExtensionTests.xctest */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -228,35 +198,12 @@
 			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* Wineskin Winery */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = A1001B65242FEA0900308B79 /* Products */;
-					ProjectRef = A1001B64242FEA0900308B79 /* ObjectiveC_Extension.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				8D1107260486CEB800E47090 /* Wineskin Winery */,
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		A1001B6A242FEA0900308B79 /* ObjectiveC_Extension.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = ObjectiveC_Extension.framework;
-			remoteRef = A1001B69242FEA0900308B79 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		A1001B6C242FEA0900308B79 /* ObjectiveC_ExtensionTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = ObjectiveC_ExtensionTests.xctest;
-			remoteRef = A1001B6B242FEA0900308B79 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		8D1107290486CEB800E47090 /* Resources */ = {

--- a/Wineskin.xcworkspace/contents.xcworkspacedata
+++ b/Wineskin.xcworkspace/contents.xcworkspacedata
@@ -10,4 +10,7 @@
    <FileRef
       location = "group:Wineskin Winery/Wineskin Winery.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:ObjectiveC_Extension/ObjectiveC_Extension.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/WineskinLauncher/WineskinLauncher.xcodeproj/project.pbxproj
+++ b/WineskinLauncher/WineskinLauncher.xcodeproj/project.pbxproj
@@ -8,8 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		A12A7F01256D50D600857FF7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = A12A7F00256D50D600857FF7 /* main.m */; };
-		A1A1FB4428F068530036F1F3 /* ObjectiveC_Extension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A12A7F0D256D514600857FF7 /* ObjectiveC_Extension.framework */; };
-		A1A1FB4528F068530036F1F3 /* ObjectiveC_Extension.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A12A7F0D256D514600857FF7 /* ObjectiveC_Extension.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A1DB8DC92570A16600631D3F /* WineskinLauncherAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A1DB8DC82570A16600631D3F /* WineskinLauncherAppDelegate.m */; };
 		A1DB8DD02570A18300631D3F /* NSPortManager.m in Sources */ = {isa = PBXBuildFile; fileRef = A1DB8DCA2570A18200631D3F /* NSPortManager.m */; };
 		A1DB8DD12570A18300631D3F /* NSWineskinEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = A1DB8DCD2570A18300631D3F /* NSWineskinEngine.m */; };
@@ -20,23 +18,6 @@
 		A1DB8DDE2570A1A500631D3F /* NSFileManager+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = A1DB8DDC2570A1A500631D3F /* NSFileManager+Extension.m */; };
 		A1DB8DE12570A25800631D3F /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1DB8DE02570A25700631D3F /* Cocoa.framework */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		A12A7F0C256D514600857FF7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A12A7F07256D514600857FF7 /* ObjectiveC_Extension.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 4E6C51071F7E8EB700A187E9;
-			remoteInfo = ObjectiveC_Extension;
-		};
-		A12A7F0E256D514600857FF7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A12A7F07256D514600857FF7 /* ObjectiveC_Extension.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 4E6C51101F7E8EB700A187E9;
-			remoteInfo = ObjectiveC_ExtensionTests;
-		};
-/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		A12A7EFB256D50D600857FF7 /* CopyFiles */ = {
@@ -54,7 +35,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				A1A1FB4528F068530036F1F3 /* ObjectiveC_Extension.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -64,7 +44,6 @@
 /* Begin PBXFileReference section */
 		A12A7EFD256D50D600857FF7 /* wineskinlauncher */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = wineskinlauncher; sourceTree = BUILT_PRODUCTS_DIR; };
 		A12A7F00256D50D600857FF7 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		A12A7F07256D514600857FF7 /* ObjectiveC_Extension.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ObjectiveC_Extension.xcodeproj; path = ../../ObjectiveC_Extension/ObjectiveC_Extension.xcodeproj; sourceTree = "<group>"; };
 		A1DB8DC72570A16600631D3F /* WineskinLauncherAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WineskinLauncherAppDelegate.h; sourceTree = "<group>"; };
 		A1DB8DC82570A16600631D3F /* WineskinLauncherAppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WineskinLauncherAppDelegate.m; sourceTree = "<group>"; };
 		A1DB8DCA2570A18200631D3F /* NSPortManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSPortManager.m; sourceTree = "<group>"; };
@@ -90,7 +69,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A1A1FB4428F068530036F1F3 /* ObjectiveC_Extension.framework in Frameworks */,
 				A1DB8DE12570A25800631D3F /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -101,7 +79,6 @@
 		A12A7EF4256D50D600857FF7 = {
 			isa = PBXGroup;
 			children = (
-				A12A7F07256D514600857FF7 /* ObjectiveC_Extension.xcodeproj */,
 				A1DB8DBF25709E4A00631D3F /* Classes */,
 				A1DB8DC625709EB600631D3F /* Other Sources */,
 				A12A7F10256D514F00857FF7 /* Frameworks */,
@@ -113,15 +90,6 @@
 			isa = PBXGroup;
 			children = (
 				A12A7EFD256D50D600857FF7 /* wineskinlauncher */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		A12A7F08256D514600857FF7 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				A12A7F0D256D514600857FF7 /* ObjectiveC_Extension.framework */,
-				A12A7F0F256D514600857FF7 /* ObjectiveC_ExtensionTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -244,35 +212,12 @@
 			mainGroup = A12A7EF4256D50D600857FF7;
 			productRefGroup = A12A7EFE256D50D600857FF7 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = A12A7F08256D514600857FF7 /* Products */;
-					ProjectRef = A12A7F07256D514600857FF7 /* ObjectiveC_Extension.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				A12A7EFC256D50D600857FF7 /* wineskinlauncher */,
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		A12A7F0D256D514600857FF7 /* ObjectiveC_Extension.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = ObjectiveC_Extension.framework;
-			remoteRef = A12A7F0C256D514600857FF7 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		A12A7F0F256D514600857FF7 /* ObjectiveC_ExtensionTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = ObjectiveC_ExtensionTests.xctest;
-			remoteRef = A12A7F0E256D514600857FF7 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXSourcesBuildPhase section */
 		A12A7EF9256D50D600857FF7 /* Sources */ = {


### PR DESCRIPTION
This PR adds https://github.com/vitor251093/ObjectiveC_Extension as a subproject in the workspace and removes Carthage package manager, since it was used only for this library.
Related issue is https://github.com/vitor251093/wineskin/issues/53

First commit c11be59232564628eeac634d2511a62a5e4d22a1 just adds whole repo without any other changes, so review can be easily done/skipped.
In second commit 77c8974f9485fe84750a6b19da686146c4a9a148 I removed references to ObjectiveC_Extension project from WineskinLauncher and Wineskin Winery, and upon adding the project to the workspace I linked it only with Wineskin Winery since launcher built successfully without it, so I'm guessing it doesn't need it.

My next goal is cleaning up this library and removing unnecessary things from it, because I suspect it has a lot of things which aren't used, and there are many warnings coming from the library.