### PR TITLE
Correct second copy of Winetricks URL

### DIFF
--- a/WineskinApp/Classes/Controller/WineskinAppDelegate.m
+++ b/WineskinApp/Classes/Controller/WineskinAppDelegate.m
@@ -1140,7 +1140,7 @@ NSFileManager *fm;
 - (IBAction)winetricksUpdateButtonPressed:(id)sender
 {
     //Get the URL where winetricks is located
-    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://raw.githubusercontent.com/The-Wineskin-Project/WineskinServer/main/WineskinWinetricks/Location.txt?%@",[[NSNumber numberWithLong:rand()] stringValue]]];
+    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://raw.githubusercontent.com/The-Wineskin-Project/WineskinServer/main/Winetricks/Location.txt?%@",[[NSNumber numberWithLong:rand()] stringValue]]];
     NSString *urlWhereWinetricksIs = [NSString stringWithContentsOfURL:url encoding:NSUTF8StringEncoding timeoutInterval:5];
 
 	urlWhereWinetricksIs = [urlWhereWinetricksIs stringByReplacingOccurrencesOfString:@"\n" withString:@""]; //remove \n


### PR DESCRIPTION
The previous commit missed a second copy of the URL that is actually used by the UI